### PR TITLE
Check if $message returns false

### DIFF
--- a/src/lib/default/diffbackend/exportchangesdiff.php
+++ b/src/lib/default/diffbackend/exportchangesdiff.php
@@ -160,7 +160,8 @@ class ExportChangesDiff extends DiffState implements IExportChanges{
                         $message = $this->backend->GetMessage($this->folderid, $change["id"], $this->contentparameters);
 
                         // copy the flag to the message
-                        $message->flags = (isset($change["flags"])) ? $change["flags"] : 0;
+                        if($message)
+                            $message->flags = (isset($change["flags"])) ? $change["flags"] : 0;
 
                         if($stat && $message) {
                             if($this->flags & BACKEND_DISCARD_DATA || $this->importer->ImportMessageChange($change["id"], $message) == true)


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3.

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
backend->GetMessage can return false instead of an object. Check before setting flag.


Does this close any currently open issues?
------------------------------------------
[https://github.com/Z-Hub/Z-Push/issues/5](https://github.com/Z-Hub/Z-Push/issues/5)


Any relevant logs, error output, etc?
-------------------------------------
same as raised in issue

PHP message: PHP Fatal error: Uncaught Error: Attempt to assign property "flags" on bool in /z-push/lib/default/diffbackend/exportchangesdiff.p
hp:163


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Ubuntu 22.04
 - PHP Version: 8.2 
 - Backend for: CardDav
 - and Version: NA

**Smartphone (please complete the following information):**
 - Device: Xiaomi and Computer
 - OS: Android and windows
 - Mail App GMail and Thunderbird with TBSync
 - Version latest

Recreated same issue as in Zimbra backend with CardDav backend. Likely affected all backends when returning false occurred.