### PR TITLE
Update z-push-top.php

### DIFF
--- a/src/z-push-top.php
+++ b/src/z-push-top.php
@@ -80,6 +80,7 @@ class ZPushTop {
     const SHOW_ACTIVE_ONLY = 1;
     const SHOW_UNKNOWN_ONLY = 2;
     const SHOW_TERM_DEFAULT_TIME = 5; // 5 secs
+    const SHOW_PID_CHARS = 7; //The PID_MAX_LIMIT can be set to any value up to 2^22 (approximately 4 million)
 
     private $topCollector;
     private $starttime;
@@ -666,10 +667,10 @@ class ZPushTop {
      */
     private function getLine($l) {
         if ($this->wide === true)
-            return sprintf("%s%s%s%s%s%s%s%s", $this->ptStr($l['pid'],6), $this->ptStr($l['ip'],16), $this->ptStr($l['user'],24), $this->ptStr($l['command'],16), $this->ptStr($this->sec2min($l['time']),8), $this->ptStr($l['devagent'],28), $this->ptStr($l['devid'],33, true), $l['addinfo']);
+            return sprintf("%s%s%s%s%s%s%s%s", $this->ptStr($l['pid'],self::SHOW_PID_CHARS+1), $this->ptStr($l['ip'],16), $this->ptStr($l['user'],24), $this->ptStr($l['command'],16), $this->ptStr($this->sec2min($l['time']),8), $this->ptStr($l['devagent'],28), $this->ptStr($l['devid'],33, true), $l['addinfo']);
         else
-            return sprintf("%s%s%s%s%s%s%s%s", $this->ptStr($l['pid'],6), $this->ptStr($l['ip'],16), $this->ptStr($l['user'],8), $this->ptStr($l['command'],8), $this->ptStr($this->sec2min($l['time']),6), $this->ptStr($l['devagent'],20), $this->ptStr($l['devid'],12, true), $l['addinfo']);
-    }
+            return sprintf("%s%s%s%s%s%s%s%s", $this->ptStr($l['pid'],self::SHOW_PID_CHARS+1), $this->ptStr($l['ip'],16), $this->ptStr($l['user'],8), $this->ptStr($l['command'],8), $this->ptStr($this->sec2min($l['time']),6), $this->ptStr($l['devagent'],20), $this->ptStr($l['devid'],12, true), $l['addinfo']);
+     }
 
     /**
      * Pads and trims string


### PR DESCRIPTION
The max value for PIDs on 64-bit linux is 2^22 (approx 4 million) so 7 characters are needed to display the column reliably.

Released under the GNU Affero General Public License (AGPL), version 3

<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
On a Rocky Linux 9 server, z-push-top.php is currently displaying PIDs as  "724.." - this is not useful for isolating individual running syncs. As the max PID value on 64-bit linux systems can be 2^22 (approx 4 million) the PID column should be widened to display 7 chars. 
...


Does this close any currently open issues?
------------------------------------------
No
...


Any relevant logs, error output, etc?
-------------------------------------

Before: 
```
PID   IP
724.. 192.168.120.123

```
After: 
```
PID     IP
724103  192.168.120.123 

```
...


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Rocky Linux 9
 - PHP Version: 8.1.14 
 - and Version: [2.7.0]

 - OS: Rocky Linux 8
 - PHP Version: 7.4.33
 - and Version: [2.6.4]

**Smartphone (please complete the following information):**
 - Device: Not applicable
