### PR TITLE
Replace deprecated gmstrftime PHP function

### DIFF
--- a/src/backend/kopano/mapiprovider.php
+++ b/src/backend/kopano/mapiprovider.php
@@ -1286,12 +1286,12 @@ class MAPIProvider {
 
             if (isset($existingstartendprops[$amapping["starttime"]]) && !isset($appointment->starttime)) {
                 $appointment->starttime = $existingstartendprops[$amapping["starttime"]];
-                ZLog::Write(LOGLEVEL_WBXML, sprintf("MAPIProvider->setAppointment(): Parameter 'starttime' was not set, using value from MAPI %d (%s).", $appointment->starttime, gmstrftime("%Y%m%dT%H%M%SZ", $appointment->starttime)));
+                ZLog::Write(LOGLEVEL_WBXML, sprintf("MAPIProvider->setAppointment(): Parameter 'starttime' was not set, using value from MAPI %d (%s).", $appointment->starttime, Utils::FormatDateUtc($appointment->starttime,"yyyyMMdd'T'HHmmSS'Z'")));
             }
             if (isset($existingstartendprops[$amapping["endtime"]]) && !isset($appointment->endtime)) {
                 $appointment->endtime = $existingstartendprops[$amapping["endtime"]];
-                ZLog::Write(LOGLEVEL_WBXML, sprintf("MAPIProvider->setAppointment(): Parameter 'endtime' was not set, using value from MAPI %d (%s).", $appointment->endtime, gmstrftime("%Y%m%dT%H%M%SZ", $appointment->endtime)));
-            }
+                ZLog::Write(LOGLEVEL_WBXML, sprintf("MAPIProvider->setAppointment(): Parameter 'endtime' was not set, using value from MAPI %d (%s).", $appointment->endtime, Utils::FormatDateUtc($appointment->endtime,"yyyyMMdd'T'HHmmSS'Z'")));
+                }
         }
         if (!isset($appointment->starttime) || !isset($appointment->endtime)) {
             throw new StatusException("MAPIProvider->setAppointment(): Error, start and/or end time not set and can not be retrieved from MAPI.", SYNC_STATUS_SYNCCANNOTBECOMPLETED);

--- a/src/lib/core/streamer.php
+++ b/src/lib/core/streamer.php
@@ -458,7 +458,7 @@ class Streamer implements Serializable {
      */
     private function formatDate($ts, $type) {
         if ('' === $ts) {
-          $ts = null;
+            return $ts;
         }
       
         if($type == self::STREAMER_TYPE_DATE)

--- a/src/lib/core/streamer.php
+++ b/src/lib/core/streamer.php
@@ -462,9 +462,9 @@ class Streamer implements Serializable {
         }
       
         if($type == self::STREAMER_TYPE_DATE)
-            return gmstrftime("%Y%m%dT%H%M%SZ", $ts);
+            return Utils::FormatDateUtc($ts,"yyyyMMdd'T'HHmmSS'Z'");
         else if($type == self::STREAMER_TYPE_DATE_DASHES)
-            return gmstrftime("%Y-%m-%dT%H:%M:%S.000Z", $ts);
+            return Utils::FormatDateUtc($ts,"yyyy-MM-dd'T'HH:mm:SS'.000Z'");
     }
 
     /**

--- a/src/lib/syncobjects/syncappointment.php
+++ b/src/lib/syncobjects/syncappointment.php
@@ -266,12 +266,12 @@ class SyncAppointment extends SyncObject {
             // Case 1, 3a (endtime won't be changed as it's set)
             if (!isset($this->starttime)) {
                 $this->starttime = $calcstart;
-                ZLog::Write(LOGLEVEL_WBXML, sprintf("SyncAppointment->Check(): Parameter 'starttime' was not set, setting it to %d (%s).", $this->starttime, gmstrftime("%Y%m%dT%H%M%SZ", $this->starttime)));
+                ZLog::Write(LOGLEVEL_WBXML, sprintf("SyncAppointment->Check(): Parameter 'starttime' was not set, setting it to %d (%s).", $this->starttime, Utils::FormatDateUtc($this->starttime,"yyyyMMdd'T'HHmmSS'Z'")));
             }
             // Case 1, 4
             if (!isset($this->endtime)) {
                 $this->endtime = $calcstart + 1800; // 30 min after calcstart
-                ZLog::Write(LOGLEVEL_WBXML, sprintf("SyncAppointment->Check(): Parameter 'endtime' was not set, setting it to %d (%s).", $this->endtime, gmstrftime("%Y%m%dT%H%M%SZ", $this->endtime)));
+                ZLog::Write(LOGLEVEL_WBXML, sprintf("SyncAppointment->Check(): Parameter 'endtime' was not set, setting it to %d (%s).", $this->endtime, Utils::FormatDateUtc($this->endtime,"yyyyMMdd'T'HHmmSS'Z'")));
             }
         }
 

--- a/src/lib/utils/utils.php
+++ b/src/lib/utils/utils.php
@@ -1465,6 +1465,30 @@ class Utils {
 
         return $contents;
     }
+
+    /**
+     * Creates a Compact DateTime from a UTC Timestamp - Formats used for ActiveSync yyyyMMddTHHmmSSZ and yyyy-MM-ddTHH:mm:SS.000Z
+     *
+     * @param timestamp    $ts
+	 *
+	 * @param string       $format
+     *
+     * @access public
+     * @return string
+     */
+    public static function FormatDateUtc($ts,$format) {
+
+        $dateFormatUtc = datefmt_create(
+            'en_US',
+            IntlDateFormatter::FULL,
+            IntlDateFormatter::FULL,
+            'UTC',
+            IntlDateFormatter::GREGORIAN, 
+            $format
+        );
+        return datefmt_format($dateFormatUtc, $ts);
+    }
+
 }
 
 // TODO Win1252/UTF8 functions are deprecated and will be removed sometime


### PR DESCRIPTION
gmstrftime - Warning: This function has been DEPRECATED as of PHP 8.1.0. Relying on this function is highly discouraged.

Adding a new static function to Utils.php to generate the the required Compact Date strings to send to the device.

Released under the GNU Affero General Public License (AGPL), version 3


What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a new function to Utils.php 

    public static function FormatDateUtc($ts,$format) {

and replaces calls to the deprecated gmstrftime with calls to this new function 
 
...


Does this close any currently open issues?
------------------------------------------
No.
...


Any relevant logs, error output, etc?
-------------------------------------
...


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Rocky Linux 9
 - PHP Version: 8.1.14 
 - Backend for: Zimbra
 - and Version: z-push 2.7

**Smartphone (please complete the following information):**
 - Device: Galaxy S21
 - OS: Android 13, One UI 5.1
 - Mail App Samsung Email 
 - Version 6.1.75