### PR TITLE
Update version.php

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -27,8 +27,13 @@ if (!defined("ZPUSH_VERSION")) {
     $path = escapeshellarg(dirname(realpath($_SERVER['SCRIPT_FILENAME'])));
     $branch = trim(exec("hash git 2>/dev/null && cd $path >/dev/null 2>&1 && git branch --no-color 2>/dev/null | sed -e '/^[^*]/d' -e \"s/* \(.*\)/\\1/\""));
     $version = exec("hash git 2>/dev/null && cd $path >/dev/null 2>&1 && git describe  --always 2>/dev/null");
+    $file = dirname(realpath($_SERVER['SCRIPT_FILENAME'])) . '/version';
     if ($branch && $version) {
         define("ZPUSH_VERSION", $branch .'-'. $version);
+    }
+    elseif (file_exists($file)) {
+        $line = fgets(fopen($file, 'r'));
+        define("ZPUSH_VERSION", $line);
     }
     else {
         define("ZPUSH_VERSION", "GIT");


### PR DESCRIPTION
To include version when not coming from a git clone. such as Mail in a boxes use. Need a text file named version in the same directory as version.php

<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
To include version when not coming from a git clone. such as Mail in a boxes use. Need a text file named version in the same directory as version.php


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
No


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Ubuntu 22.04 LTS
 - PHP Version: 8.0 and 8.2
 - Backend for: Mail-in-a-Box
 - and Version: v62

**Smartphone (please complete the following information):**
 - Device: Xiaomi 11T
 - OS: Android 13
 - Mail App GMail
 - Version current
