### PR TITLE
Fix error mb_convert_encoding(): Argument #3 ($from_encoding) contains invalid encoding "windows-1256"

### DIFF
--- a/src/lib/utils/utils.php
+++ b/src/lib/utils/utils.php
@@ -1278,7 +1278,11 @@ class Utils {
                 $str .= $val->text;
             }
             else {
-                $str .= @mb_convert_encoding($val->text, "utf-8", $val->charset);
+                try {
+                    $str .= @mb_convert_encoding($val->text, "utf-8", $val->charset);
+                } catch (ValueError $exception) {
+                    $str .= @iconv($val->charset, "utf-8", $val->text);
+                }
             }
         }
         if (!$isiso2022jp) {


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3.

<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the error below happening all the time when running Z-Push with PHP 8 (`mb_convert_encoding` now throws an error when `$to_encoding` or `$from_encoding` is an invalid encodig):

```
[error] 690771#690771: *3590124 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught ValueError: mb_convert_encoding(): Argument #3 ($from_encoding) contains invalid encoding "windows-1256" in /opt/z-push/lib/utils/utils.php:1281
Stack trace:
#0 /opt/z-push/lib/utils/utils.php(1281): mb_convert_encoding()
#1 /opt/z-push/lib/utils/utils.php(1406): Utils::convertRawHeader2Utf8()
#2 /opt/z-push/backend/imap/imap.php(1154): Utils::CheckAndFixEncodingInHeaders()
#3 /opt/z-push/lib/default/diffbackend/exportchangesdiff.php(160): BackendIMAP->GetMessage()
#4 /opt/z-push/lib/request/sync.php(1199): ExportChangesDiff->Synchronize()
#5 /opt/z-push/lib/request/sync.php(956): Sync->syncFolder()
#6 /opt/z-push/lib/request/requestprocessor.php(116): Sync->Handle()
#7 /opt/z-push/index.php(107): RequestProcessor::HandleRequest()
#8 {main}
  thrown in /opt/z-push/lib/utils/utils.php on line 1281" while reading response header from upstream, ...
```

The fix is copied from https://github.com/nextcloud/mail/pull/5593. More information there.

Does this close any currently open issues?
------------------------------------------
At the time of this PR I haven't found any open issue about this error.


Any relevant logs, error output, etc?
-------------------------------------
See error log above.


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Debian bullseye
 - PHP Version: 8.2
 - Backend for: IMAP
 - and Version: 2.7.0

**Smartphone (please complete the following information):**
 The log above is found for POST /Microsoft-Server-ActiveSync queries with at least these DeviceType:
- iPhone
- Outlook
- Android
- SamsungDevice
This is probably not exhaustive.


I'm not familiar at all with Z-Push's code base, feel free to modify however you think is best, or close and open an other PR with a better fix.