### PR TITLE
PHP8.0 mail() to use /r/n line endings

### DIFF
--- a/src/backend/imap/Mail/mail.php
+++ b/src/backend/imap/Mail/mail.php
@@ -91,10 +91,12 @@ class Mail_mail extends Mail {
         /* Because the mail() function may pass headers as command
          * line arguments, we can't guarantee the use of the standard
          * "\r\n" separator.  Instead, we use the system's native line
-         * separator. */
-        if (defined('PHP_EOL')) {
+         * separator.
+         * Fixed in PHP 8.0.
+         */
+        if (defined('PHP_EOL') && version_compare(PHP_VERSION, '8.0.0', '<')) {
             $this->sep = PHP_EOL;
-        } else {
+        } elseif (version_compare(PHP_VERSION, '8.0.0', '<')) {
             $this->sep = (strpos(PHP_OS, 'WIN') === false) ? "\n" : "\r\n";
         }
     }


### PR DESCRIPTION
Used less than PHP 8.0, as this is a breaking change for PHP 7.4.

<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Reported issue for users of PHP8.0+ using PHP mail() to send.

The change for 8.0 is explained well on this Drupal issue https://www.drupal.org/project/drupal/issues/3270647


Does this close any currently open issues?
------------------------------------------
#24 error sending mail: corrupt headers


Any relevant logs, error output, etc?
-------------------------------------
Just the ones in the issue


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Ubuntu 22.04
 - PHP Version: 7.4 / 8.0
 - Backend for: IMAP / Mail-in-a-Box
 - and Version: Mail-in-a-Box v63

**Smartphone (please complete the following information):**
 - Device: Xiaomi 11T
 - OS: Android 13
 - Mail App: GMail 
 - Version 2023.07.23
