### PR TITLE
Fix some PHP8 errors for IMAP backend

### DIFF
--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -1022,7 +1022,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
 
         if ($cutoffdate > 0) {
             // IMAP SINCE search criteria
-            $searchCriteria = "SINCE ". date("d-M-Y", $cutoffdate);
+            $searchCriteria = "SINCE ". date("d-M-Y", (int) $cutoffdate);
 
             // search messages in time range
             $search = @imap_search($this->mbox, $searchCriteria);
@@ -1128,7 +1128,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
     public function GetMessage($folderid, $id, $contentparameters) {
         $truncsize = Utils::GetTruncSize($contentparameters->GetTruncation());
         $mimesupport = $contentparameters->GetMimeSupport();
-        $bodypreference = $contentparameters->GetBodyPreference(); /* fmbiete's contribution r1528, ZP-320 */
+        $bodypreference = $contentparameters->GetBodyPreference() ?: []; /* fmbiete's contribution r1528, ZP-320 */
         ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendIMAP->GetMessage('%s', '%s', '%s')", $folderid,  $id, implode(",", $bodypreference)));
 
         $folderImapid = $this->getImapIdFromFolderId($folderid);
@@ -1167,7 +1167,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
 
             // Detect Apple iOS devices
             $isAppleIosDevice = false;
-            $deviceType = strtolower(Request::GetDeviceType());
+            $deviceType = strtolower(Request::GetDeviceType() ?? '');
             if ($deviceType == 'iphone' || $deviceType == 'ipad' || $deviceType == 'ipod') {
                 ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendIMAP->GetMessage():: iOS device %s->%s detected", Request::GetDeviceType(), Request::GetUserAgent()));
                 $isAppleIosDevice = true;
@@ -2505,6 +2505,9 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
      * @return
      */
     protected function getModAndParentNames($fhir, &$displayname, &$parent) {
+        if (is_string($fhir)) {
+            $fhir = [$fhir];
+        }
         // if mod is already set add the previous part to it as it might be a folder which has delimiter in its name
         $displayname = (isset($displayname) && strlen($displayname) > 0) ? $displayname = array_pop($fhir) . $this->getServerDelimiter() . $displayname : array_pop($fhir);
         $parent = implode($this->getServerDelimiter(), $fhir);


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms.

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes some errors with PHP 8.x for the IMAP backend. In particular [this](https://github.com/Z-Hub/Z-Push/compare/develop...DoobleD:Z-Push:develop#diff-f19d393f43f8d9cb06d75aec94459e675681ec15e65baf8a20abe6d1450ba3a9L1131-R1131) change line 1131 fixes these 2 fatal errors:

`[FATAL] [<user>] Fatal error: /<path>/z-push/backend/imap/imap.php:1132 - Uncaught TypeError: implode(): Argument #2 ($array) must be of type ?array, bool given in /<path>/z-push/backend/imap/imap.php:1132
`

and

`[FATAL] [<user>] Fatal error: /<path>/z-push/backend/imap/imap.php:1177 - Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, bool given in /<path>/z-push/backend/imap/imap.php:1177`

Does this close any currently open issues?
------------------------------------------
Not that I know of.


Any relevant logs, error output, etc?
-------------------------------------
See above.


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Debian 11
 - PHP Version: 8.2
 - Backend for: IMAP
 - and Version: 7.1

**Smartphone (please complete the following information):**
 - Device: Android
 - OS: Android 13
 - Mail App: Outlook
 - Version: 4.2338.0
