### PR TITLE
Duplicate-Pings-With-Same-Timestamp

### DIFF
--- a/src/lib/core/pingtracking.php
+++ b/src/lib/core/pingtracking.php
@@ -107,8 +107,21 @@ class PingTracking extends InterProcessData {
         // check if there is another (and newer) active ping connection
         if (is_array($pings) && isset($pings[self::$devid][self::$user]) && count($pings[self::$devid][self::$user]) > 1) {
             foreach ($pings[self::$devid][self::$user] as $pid=>$starttime)
-                if ($starttime > self::$start)
+                if ($starttime > self::$start) {
+ZLog::Write(LOGLEVEL_DEBUG, "MultiPINGS: " . "Other process starttime after mine so terminate me - return TRUE");
                     return true;
+				}
+                elseif ($starttime == self::$start) {
+                    if ($pid > self::$pid) {
+ZLog::Write(LOGLEVEL_DEBUG, "MultiPINGS: " . 'Other process [' . $pid .'] starttime same as mine : Other process ID is "bigger" than mine - return TRUE');
+                        return true;
+                    } elseif ($pid < self::$pid) {
+ZLog::Write(LOGLEVEL_DEBUG, "MultiPINGS: " . 'Other process [' . $pid .'] starttime same as mine : Other process ID is "smaller" than mine - return FALSE');
+                    }
+                    else {
+ZLog::Write(LOGLEVEL_DEBUG, "MultiPINGS: " . 'This is my PID - Ignore me - return FALSE');
+                    }
+                }
         }
 
         return false;

--- a/src/lib/core/pingtracking.php
+++ b/src/lib/core/pingtracking.php
@@ -108,18 +108,13 @@ class PingTracking extends InterProcessData {
         if (is_array($pings) && isset($pings[self::$devid][self::$user]) && count($pings[self::$devid][self::$user]) > 1) {
             foreach ($pings[self::$devid][self::$user] as $pid=>$starttime)
                 if ($starttime > self::$start) {
-ZLog::Write(LOGLEVEL_DEBUG, "MultiPINGS: " . "Other process starttime after mine so terminate me - return TRUE");
                     return true;
 				}
                 elseif ($starttime == self::$start) {
+                    // Arbitrary decision to differentiate multiple processes that started at the same second for the same user. Compare PIDs
+                    // If the other process has a bigger PID then kill this process
                     if ($pid > self::$pid) {
-ZLog::Write(LOGLEVEL_DEBUG, "MultiPINGS: " . 'Other process [' . $pid .'] starttime same as mine : Other process ID is "bigger" than mine - return TRUE');
                         return true;
-                    } elseif ($pid < self::$pid) {
-ZLog::Write(LOGLEVEL_DEBUG, "MultiPINGS: " . 'Other process [' . $pid .'] starttime same as mine : Other process ID is "smaller" than mine - return FALSE');
-                    }
-                    else {
-ZLog::Write(LOGLEVEL_DEBUG, "MultiPINGS: " . 'This is my PID - Ignore me - return FALSE');
                     }
                 }
         }


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. 

What does this implement/fix? Explain your changes.
---------------------------------------------------
This code detects when two or more Ping Requests from the same device/user have the same start timestamp and tells the ones with the smaller PID to self-terminate


Does this close any currently open issues?
------------------------------------------
Fixes issue #55 


Any relevant logs, error output, etc?
-------------------------------------
Initial check-in includes DEBUG logs to demonstrate the functionality. These should be removed once the fix has been accepted. 

	Line 1196: 16/02/2024 16:08:17 [1496456] [DEBUG] MultiPINGS: Other process [31200] starttime same as mine : Other process ID is "smaller" than mine - return FALSE
	Line 1197: 16/02/2024 16:08:17 [1496456] [DEBUG] MultiPINGS: This is my PID - Ignore me - return FALSE
	Line 1503: 16/02/2024 16:09:17 [31200] [DEBUG] MultiPINGS: This is my PID - Ignore me - return FALSE
	Line 1504: 16/02/2024 16:09:17 [31200] [DEBUG] MultiPINGS: Other process [1496456] starttime same as mine : Other process ID is "bigger" than mine - return TRUE



Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Rocky Linux 9
 - PHP Version: 8.1 
 - Backend for: zimbra
 - and Version: 2.7.1

**Smartphone (please complete the following information):**
 - Device: Samsung S10
 - OS: Android 12
 - Mail App GMail 
 - Version Android-Mail/2024.01.28...
