### PR TITLE
Implement AS 16 Find command to fix e-mail search on iOS 16+

### DIFF
--- a/src/lib/core/zpush.php
+++ b/src/lib/core/zpush.php
@@ -46,6 +46,8 @@ class ZPush {
     const ASV_14 = "14.0";
     const ASV_141 = "14.1";
 
+		const ASV_161 = "16.1";
+
     /**
      * Command codes for base64 encoded requests (AS >= 12.1)
      */
@@ -68,6 +70,8 @@ class ZPush {
     const COMMAND_PROVISION = 20;
     const COMMAND_RESOLVERECIPIENTS = 21;
     const COMMAND_VALIDATECERT = 22;
+
+	const COMMAND_FIND = 23;
 
     // Deprecated commands
     const COMMAND_GETHIERARCHY = -1;
@@ -122,6 +126,7 @@ class ZPush {
                     self::COMMAND_VALIDATECERT      => array(self::ASV_1,  self::REQUESTHANDLER => "ValidateCert"),
                     self::COMMAND_PROVISION         => array(self::ASV_25, self::REQUESTHANDLER => "Provisioning",  self::UNAUTHENTICATED, self::UNPROVISIONED),
                     self::COMMAND_SEARCH            => array(self::ASV_1,  self::REQUESTHANDLER => "Search"),
+	                  self::COMMAND_FIND            => array(self::ASV_141,  self::REQUESTHANDLER => "Find"), //actually belongs to 16.1 but iphone uses it anyway
                     self::COMMAND_PING              => array(self::ASV_2,  self::REQUESTHANDLER => "Ping",          self::UNPROVISIONED),
                     self::COMMAND_NOTIFY            => array(self::ASV_1,  self::REQUESTHANDLER => "Notify"),                                           // deprecated & not implemented
                     self::COMMAND_ITEMOPERATIONS    => array(self::ASV_12, self::REQUESTHANDLER => "ItemOperations"),

--- a/src/lib/request/find.php
+++ b/src/lib/request/find.php
@@ -1,0 +1,294 @@
+<?php
+/***********************************************
+* File      :   search.php
+* Project   :   Z-Push
+* Descr     :   Provides the SEARCH command
+*
+* Created   :   16.02.2012
+*
+* Copyright 2007 - 2016 Zarafa Deutschland GmbH
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License, version 3,
+* as published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* Consult LICENSE file for details
+************************************************/
+
+class Find extends RequestProcessor {
+
+    /**
+     * Handles the Search command
+     *
+     * @param int       $commandCode
+     *
+     * @access public
+     * @return boolean
+     */
+    public function Handle($commandCode) {
+
+	    $searchrange = '0';
+	    $searchpicture = false;
+
+	    $cpo = new ContentParameters();
+
+
+	    if(!self::$decoder->getElementStartTag("Find:Find")) {
+				ZLog::Write(LOGLEVEL_DEBUG, "ERROR: No find tag");
+		    return false;
+	    }
+
+
+	    if(!self::$decoder->getElementStartTag("Find:SearchId"))
+		    return false;
+	    $searchId = strtoupper(self::$decoder->getElementContent());
+	    ZLog::Write(LOGLEVEL_DEBUG, "SearchId: $searchId");
+	    if(!self::$decoder->getElementEndTag())
+		    return false;
+
+			//SearchId
+	    //ExecuteSearch
+	      //MailBoxSearchCriterion
+	        //Query
+	          //FolderType
+	          //FolderId m/Inbox
+	          //FreeText  to:"Testing1234" OR cc:"Testing1234" OR from:"Testing1234" OR subject:"Testing1234" OR "Testing1234"
+	        //Options
+	          //Range 0-99
+	          //DeepTraversal
+
+
+	    if(!self::$decoder->getElementStartTag("Find:ExecuteSearch"))
+		    return false;
+
+		    if(!self::$decoder->getElementStartTag("Find:MailBoxSearchCriterion"))
+			    return false;
+
+			    if(!self::$decoder->getElementStartTag("Find:Query"))
+				    return false;
+
+				    if (self::$decoder->getElementStartTag("FolderType")) {
+					    $searchclass = self::$decoder->getElementContent();
+
+					    ZLog::Write(LOGLEVEL_DEBUG, "FolderType: $searchclass");
+					    $cpo->SetSearchClass($searchclass);
+					    if(!self::$decoder->getElementEndTag()) {// SYNC_FOLDERTYPE
+						    ZLog::Write(LOGLEVEL_DEBUG, "ERROR: No end tag");
+						    return false;
+					    }
+				    }
+
+				    if (self::$decoder->getElementStartTag("FolderId")) {
+					    $searchfolderid = self::$decoder->getElementContent();
+					    ZLog::Write(LOGLEVEL_DEBUG, "FolderId: $searchfolderid");
+					    $cpo->SetSearchFolderid($searchfolderid);
+					    if(!self::$decoder->getElementEndTag()) {// SYNC_FOLDERTYPE
+						    ZLog::Write(LOGLEVEL_DEBUG, "ERROR: No end tag");
+						    return false;
+					    }
+				    }
+
+				    if (self::$decoder->getElementStartTag("Find:FreeText")) {
+					    $searchfreetext = self::$decoder->getElementContent();
+
+					    ZLog::Write(LOGLEVEL_DEBUG, "FreeText: $searchfreetext");
+					    $cpo->SetSearchFreeText($searchfreetext);
+					    if(!self::$decoder->getElementEndTag()) {// SYNC_FOLDERTYPE
+						    ZLog::Write(LOGLEVEL_DEBUG, "ERROR: No end tag");
+						    return false;
+					    }
+				    }
+
+			    if(!self::$decoder->getElementEndTag()) // SYNC_SEARCH_QUERY
+				    return false;
+
+
+			    if(self::$decoder->getElementStartTag("Find:Options")) {
+
+				    if (self::$decoder->getElementStartTag("Find:Range")) {
+					    $searchrange = self::$decoder->getElementContent();
+					    ZLog::Write(LOGLEVEL_DEBUG, "Range: $searchrange");
+					    $cpo->SetSearchRange($searchrange);
+					    if (!self::$decoder->getElementEndTag())
+						    return false;
+				    }
+
+				    if (self::$decoder->getElementStartTag("Find:DeepTraversal")) {
+					    $deeptraversal = true;
+					    if (($dam = self::$decoder->getElementContent()) !== false) {
+						    $deeptraversal = true;
+						    if (!self::$decoder->getElementEndTag()) {
+							    return false;
+						    }
+					    }
+					    $cpo->SetSearchDeepTraversal($deeptraversal);
+				    }
+				    if (!self::$decoder->getElementEndTag())
+					    return false;
+			    }
+
+				if(!self::$decoder->getElementEndTag()) // MailBoxSearchCriterion
+		      return false;
+
+	    if(!self::$decoder->getElementEndTag()) // ExecuteSearch
+		    return false;
+
+	    if(!self::$decoder->getElementEndTag()) //find
+		    return false;
+
+			ZLog::Write(LOGLEVEL_DEBUG, var_export($cpo->GetDataArray(), true));
+
+
+
+
+	    $searchprovider = ZPush::GetSearchProvider();
+	    $status = SYNC_SEARCHSTATUS_SUCCESS;
+	    $searchtotal = 0;
+	    $rows = array();
+
+	    // TODO support other searches
+
+	    switch($searchclass) {
+		    case "Email":
+					try {
+						if ($searchprovider->SupportsType(ISearchProvider::SEARCH_MAILBOX)) {
+							$backendFolderId = self::$deviceManager->GetBackendIdForFolderId($cpo->GetSearchFolderid());
+							$cpo->SetSearchFolderid($backendFolderId);
+							$rows = $searchprovider->GetMailboxSearchResults($cpo);
+						} else {
+							$rows = array('searchtotal' => 0);
+							$status = SYNC_SEARCHSTATUS_SERVERERROR;
+							ZLog::Write(LOGLEVEL_WARN, sprintf("Searchtype '%s' is not supported.", $searchclass));
+							self::$topCollector->AnnounceInformation(sprintf("Unsupported type '%s''", $searchclass), true);
+						}
+					} catch(StatusException $stex) {
+						$storestatus = $stex->getCode();
+					}
+					break;
+
+		    case "GAL":
+					//TODO
+//			    $rows = $searchprovider->GetGALSearchResults($searchquery, $searchrange, $searchpicture);
+					break;
+	    }
+
+	    if (isset($rows['range'])) {
+		    $searchrange = $rows['range'];
+		    unset($rows['range']);
+	    }
+	    if (isset($rows['searchtotal'])) {
+		    $searchtotal = $rows['searchtotal'];
+		    unset($rows['searchtotal']);
+	    }
+
+
+	    self::$encoder->startWBXML();
+	    self::$encoder->startTag("Find:Find");
+
+	    self::$encoder->startTag("Find:Status");
+	      self::$encoder->content($status);
+	    self::$encoder->endTag();
+
+	      self::$encoder->startTag("Find:Response");
+
+	        self::$encoder->startTag("ItemOperations:Store");
+	        self::$encoder->content("m/INBOX");
+	        self::$encoder->endTag(); // Store
+
+				    self::$encoder->startTag("Find:Status");
+				      self::$encoder->content($status);
+				    self::$encoder->endTag();
+
+
+
+				    foreach ($rows as $u) {
+					    $folderid = self::$deviceManager->GetFolderIdForBackendId($u['folderid']);
+
+					    $tmp = explode(":", $u['longid']);
+					    $message = self::$backend->Fetch($u['folderid'], $tmp[1], $cpo);
+							
+							/** @var SyncMail $message */
+
+					    self::$encoder->startTag("Find:Result");
+						    self::$encoder->startTag("FolderType"); //Class
+						    self::$encoder->content($u['class']);
+						    self::$encoder->endTag();
+						    self::$encoder->startTag("ServerEntryId"); //ServerId
+						    self::$encoder->content($tmp[1]);
+						    self::$encoder->endTag();
+						    self::$encoder->startTag("FolderId"); //CollectionId
+						    self::$encoder->content($folderid);
+						    self::$encoder->endTag();
+
+						    self::$encoder->startTag("Find:Properties");
+
+							    $message->Encode(self::$encoder);
+									
+//					      self::$encoder->startTag("POOMMAIL:Subject");
+//						    self::$encoder->content($message->subject);
+//						    self::$encoder->endTag();
+//					      self::$encoder->startTag("POOMMAIL:DateReceived");
+//						    self::$encoder->content(gmstrftime("%Y-%m-%dT%H:%M:%S.000Z", $message->datereceived));
+//						    self::$encoder->endTag();
+//					      self::$encoder->startTag("POOMMAIL:DisplayTo");
+//						    self::$encoder->content($message->displayto);
+//						    self::$encoder->endTag();
+//						    self::$encoder->startTag("Find:DisplayCc");
+//						    self::$encoder->content(implode(', ', $message->cc));
+//						    self::$encoder->endTag();
+//						    self::$encoder->startTag("Find:DisplayBcc");
+//						    self::$encoder->content("");
+//						    self::$encoder->endTag();
+//						    self::$encoder->startTag("POOMMAIL:Importance");
+//						    self::$encoder->content($message->importance);
+//						    self::$encoder->endTag();
+//						    self::$encoder->startTag("POOMMAIL:Read");
+//						    self::$encoder->content($message->read);
+//						    self::$encoder->endTag();
+//					      self::$encoder->startTag("POOMMAIL2:IsDraft");
+//					      self::$encoder->content("0");
+//					      self::$encoder->endTag();
+//						    self::$encoder->startTag("Find:Preview");
+//						    self::$encoder->content("test 123 preview...");
+//						    self::$encoder->endTag();
+//						    self::$encoder->startTag("Find:HasAttachments");
+//						    self::$encoder->content("0");
+//						    self::$encoder->endTag();
+//						    self::$encoder->startTag("POOMMAIL:From");
+//						    self::$encoder->content($message->from);
+//						    self::$encoder->endTag();
+
+
+
+
+					      self::$encoder->endTag();//properties
+
+					    self::$encoder->endTag();//result
+
+				    }
+
+				    self::$encoder->startTag("Find:Range");
+				    self::$encoder->content($searchrange);
+				    self::$encoder->endTag();
+
+				    self::$encoder->startTag("Find:Total");
+				    self::$encoder->content($searchtotal);
+				    self::$encoder->endTag();
+
+
+
+	      self::$encoder->endTag(); // Response
+
+	    self::$encoder->endTag(); //Find
+
+	    return true;
+    }
+}

--- a/src/lib/request/request.php
+++ b/src/lib/request/request.php
@@ -66,7 +66,7 @@ class Request {
     static private $getUser;
     static private $devid;
     static private $devtype;
-    static private $authUserString;
+    static private $authUserString = "";
     static private $authUser;
     static private $authDomain;
     static private $authPassword;

--- a/src/lib/utils/utils.php
+++ b/src/lib/utils/utils.php
@@ -668,6 +668,7 @@ class Utils {
             case 'MoveItems':            return ZPush::COMMAND_MOVEITEMS;
             case 'GetItemEstimate':      return ZPush::COMMAND_GETITEMESTIMATE;
             case 'MeetingResponse':      return ZPush::COMMAND_MEETINGRESPONSE;
+	          case 'Find':               return ZPush::COMMAND_FIND;
             case 'Search':               return ZPush::COMMAND_SEARCH;
             case 'Settings':             return ZPush::COMMAND_SETTINGS;
             case 'Ping':                 return ZPush::COMMAND_PING;

--- a/src/lib/wbxml/wbxmldecoder.php
+++ b/src/lib/wbxml/wbxmldecoder.php
@@ -118,6 +118,10 @@ class WBXMLDecoder extends WBXMLDefs {
     public function getElement() {
         $element = $this->getToken();
 
+				if(!$element) {
+					return false;
+				}
+
         switch($element[EN_TYPE]) {
             case EN_TYPE_STARTTAG:
                 return $element;

--- a/src/lib/wbxml/wbxmldefs.php
+++ b/src/lib/wbxml/wbxmldefs.php
@@ -774,6 +774,7 @@ class WBXMLDefs {
                   0x16 => "POOMMAIL2", //14.0
                   0x17 => "Notes", //14.0
                   0x18 => "RightsManagement",
+	                0x19 => "Find", //16.1
               )
           );
 }

--- a/src/lib/wbxml/wbxmldefs.php
+++ b/src/lib/wbxml/wbxmldefs.php
@@ -690,6 +690,9 @@ class WBXMLDefs {
                         0x11 => "AccountId", // Since 14.1
                         0x12 => "FirstDayOfWeek", // Since 14.1
                         0x13 => "MeetingMessageType", // Since 14.1
+	                      0x15 => 'IsDraft', //since 16.0
+	                      0x16 => 'Bcc', //since 16.0
+	                      0x17 => 'Send', //since 16.0
                     ),
                     0x17 => array( //Since 14.0
                         0x05 => "Subject",
@@ -720,6 +723,30 @@ class WBXMLDefs {
                         0x17 => "ContentOwner",
                         0x18 => "RemoveRightsManagementProtection",
                     ),
+	                0x19 => array( // Since 16.1
+		                0x05 => "Find",
+		                0x06 => "SearchId",
+		                0x07 => "ExecuteSearch",
+		                0x08 => "MailBoxSearchCriterion",
+		                0x09 => "Query",
+		                0x0A => "Status",
+		                0x0B => "FreeText",
+		                0x0C => "Options",
+		                0x0D => "Range",
+		                0x0E => "DeepTraversal",
+		                0x11 => "Response",
+		                0x12 => "Result",
+		                0x13 => "Properties",
+		                0x14 => "Preview",
+		                0x15 => "HasAttachments",
+		                0x16 => "Total",
+		                0x17 => "DisplayCc",
+		                0x18 => "DisplayBcc",
+		                0x19 => "GalSearchCriterion",
+		                0x20 => "MaxPictures",
+		                0x21 => "MaxSize",
+		                0x22 => "Picture",
+	                ),
               ),
               "namespaces" => array(
                   //0 => "AirSync", //

--- a/src/z-push-top.php
+++ b/src/z-push-top.php
@@ -84,17 +84,17 @@ class ZPushTop {
 
     private $topCollector;
     private $starttime;
-    private $action;
-    private $filter;
-    private $status;
-    private $statusexpire;
-    private $wide;
+    private $action = "";
+    private $filter = false;
+    private $status = false;
+    private $statusexpire = 0;
+    private $wide = false;
     private $wasEnabled;
-    private $terminate;
-    private $scrSize;
+    private $terminate = false;
+    private $scrSize = array('width' => 80, 'height' => 24);
     private $pingInterval;
-    private $showPush;
-    private $showTermSec;
+    private $showPush = true;
+    private $showTermSec = self::SHOW_TERM_DEFAULT_TIME;
 
     private $linesActive = array();
     private $linesOpen = array();
@@ -106,8 +106,15 @@ class ZPushTop {
     private $activeUsers = array();
     private $activeDevices = array();
     private $activeBackend;
+	private ?int $currenttime ;
+	private int $helpexpire = 0;
+	/**
+	 * @var false
+	 */
+	private bool $doingTail = false;
+	private int $showOption = self::SHOW_DEFAULT;
 
-    /**
+	/**
      * Constructor
      *
      * @access public
@@ -115,21 +122,10 @@ class ZPushTop {
     public function __construct() {
         $this->starttime = time();
         $this->currenttime = time();
-        $this->action = "";
-        $this->filter = false;
-        $this->status = false;
-        $this->statusexpire = 0;
-        $this->helpexpire = 0;
-        $this->doingTail = false;
-        $this->wide = false;
-        $this->terminate = false;
-        $this->showPush = true;
-        $this->showOption = self::SHOW_DEFAULT;
-        $this->showTermSec = self::SHOW_TERM_DEFAULT_TIME;
-        $this->scrSize = array('width' => 80, 'height' => 24);
-        $this->pingInterval = (defined('PING_INTERVAL') && PING_INTERVAL > 0) ? PING_INTERVAL : 12;
+	    $this->pingInterval = (defined('PING_INTERVAL') && PING_INTERVAL > 0) ? PING_INTERVAL : 12;
 
-        // Identify the backend that will be loaded by z-push
+
+	    // Identify the backend that will be loaded by z-push
         $this->activeBackend = get_class(ZPush::GetBackend());
       
         // get a TopCollector


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
iOS 16 and up wrongfully sends a Find command when searching mail using Z-Push. I implemented the Find command so that searching works on iOS 16.


Does this close any currently open issues?
------------------------------------------
Fixes Error when searching mail on iphone #23


Any relevant logs, error output, etc?
-------------------------------------
No


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Linux
 - PHP Version: 8.2
 - Backend for: Group-Office
 - and Version: 6.8

**Smartphone (please complete the following information):**
 - Device: IPhone 13
 - OS: iOS 17.4
 - Mail App Apple mail

