### PR TITLE
Add iphone compatible NOTES support to IMAP backend

### DIFF
--- a/src/backend/imap/config.php
+++ b/src/backend/imap/config.php
@@ -104,6 +104,8 @@ define('IMAP_FOLDER_SPAM', 'SPAM');
 // Archive folder name (case doesn't matter). Only showed as special by iOS devices
 define('IMAP_FOLDER_ARCHIVE', 'ARCHIVE');
 
+// Apple NOTES folder (case doesn't matter)
+define('IMAP_FOLDER_NOTE', 'NOTES');
 
 
 // forward messages inline (default true - inlined)

--- a/src/lib/core/streamimporter.php
+++ b/src/lib/core/streamimporter.php
@@ -73,7 +73,7 @@ class ImportChangesStream implements IImportChanges {
         }
 
         // KOE ZO-42: to sync Notes to Outlook we sync them as Appointments
-        if ($this->classAsString == "SyncNote") {
+        if ($this->classAsString == "SyncNote" && ZPush::GetDeviceManager()->IsKoe() ) {
             if (KOE_CAPABILITY_NOTES && ZPush::GetDeviceManager()->IsKoe()) {
                 // update category from SyncNote->Color
                 $message->SetCategoryFromColor();


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This code adds support for NOTES on IMAP backup (compatible with Iphone)


Does this close any currently open issues?
------------------------------------------
...


Any relevant logs, error output, etc?
-------------------------------------
...


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: [e.g. iOS]
 - PHP Version: [e.g. 8.2] 
 - Backend for: [e.g. Kopano, Zimbra, Mail-in-a-Box]
 - and Version: [e.g. git, 9.0, v61.1]

**Smartphone (please complete the following information):**
 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Mail App [e.g. GMail, Apple Mail] 
 - Version [e.g. 22]
