### PR TITLE
Include and Exclude filter on discovered addressbook urls and discovered calendar urls

### DIFF
--- a/src/backend/caldav/config.php
+++ b/src/backend/caldav/config.php
@@ -62,5 +62,5 @@ define('CALDAV_MAX_SYNC_PERIOD', 2147483647);
 // The defined constants can either be a string or an array of multiple strings, to provide multiple filters.
 // Exclude example: '*/archived-appointments/'
 // Include example: '*sync*'
-//define('CALDAV_PATH_EXCLUDE', '');
+//define('CALDAV_PATH_INCLUDE', '');
 //define('CALDAV_PATH_EXCLUDE', '');

--- a/src/backend/caldav/config.php
+++ b/src/backend/caldav/config.php
@@ -54,3 +54,13 @@ define('CALDAV_SUPPORTS_SYNC', false);
 // Maximum period to sync.
 // Some servers don't support more than 10 years so you will need to change this
 define('CALDAV_MAX_SYNC_PERIOD', 2147483647);
+
+// Filter discovered calendar urls, by inclusion or exclusion.
+// The default is to always include the calendar collection, unless either include or exclude is uncommented and configured.
+// The calendar collection is included, either when the include filter is not configured, or when the include filter matches.
+// The calendar collection is excluded, when the exclude filter is configured and it matches. Exclude always wins over include.
+// The defined constants can either be a string or an array of multiple strings, to provide multiple filters.
+// Exclude example: '*/archived-appointments/'
+// Include example: '*sync*'
+//define('CALDAV_PATH_EXCLUDE', '');
+//define('CALDAV_PATH_EXCLUDE', '');

--- a/src/backend/carddav/config.php
+++ b/src/backend/carddav/config.php
@@ -101,5 +101,5 @@ define('CARDDAV_URL_VCARD_EXTENSION', '.vcf');
 // The defined constants can either be a string or an array of multiple strings, to provide multiple filters.
 // Exclude example: '*/archived-addresses/'
 // Include example: '*sync*'
-//define('CARDDAV_PATH_EXCLUDE', '');
+//define('CARDDAV_PATH_INCLUDE', '');
 //define('CARDDAV_PATH_EXCLUDE', '');

--- a/src/backend/carddav/config.php
+++ b/src/backend/carddav/config.php
@@ -93,3 +93,13 @@ define('CARDDAV_SUPPORTS_FN_SEARCH', false);
 //    Davical needs it
 //    SOGo official demo online needs it, but some SOGo installation don't need it, so test it
 define('CARDDAV_URL_VCARD_EXTENSION', '.vcf');
+
+// Filter discovered addressbook urls, by inclusion or exclusion.
+// The default is to always include the addressbook collection, unless either include or exclude is uncommented and configured.
+// The addressbook collection is included, either when the include filter is not configured, or when the include filter matches.
+// The addressbook collection is excluded, when the exclude filter is configured and it matches. Exclude always wins over include.
+// The defined constants can either be a string or an array of multiple strings, to provide multiple filters.
+// Exclude example: '*/archived-addresses/'
+// Include example: '*sync*'
+//define('CARDDAV_PATH_EXCLUDE', '');
+//define('CARDDAV_PATH_EXCLUDE', '');


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3

What does this implement/fix? Explain your changes.
---------------------------------------------------
Normally Z-Push discovers and delivers all address books and all calendars to the client.
I wanted an option to filter which address books and calendars, that should be delivered to the client.

This pull request adds Include and Exclude filters, that supports wildcards. Each discovered URL is matched against the filters, and only matching URLs are delivered to the client.

The filters can either be a single string, or an array of strings, to provide multiple filters.
If one or more include filter matches, the URL is allowed.
If one or more exclude filter matches, the URL is skipped.
If one or more include filter matches, and one or more exclude filter matches, the URL is skipped - exclude wins.

I know that you might be able to do something with for instance the 'CARDDAV_PATH' option, but if your CardDAV server do not support a hierarchical structure (Radicale), that is not an good option.
...


Does this close any currently open issues?
------------------------------------------
No.
...


Any relevant logs, error output, etc?
-------------------------------------
No.
...


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Debian 12
 - PHP Version: 8.2.18
 - Backend for: CardDAV, CalDAV
 - and Version: v2.7.3

**Smartphone (please complete the following information):**
 - OS: iPhone 6, Lineage OS 20 (Android 13)
 - OS: iOS 15
 - Mail App: Apple Mail and Apple Addresses, Mail and Addresses on Lineage
 - Version: 15
