### PR TITLE
Update AS version to 16 for Backends

### DIFF
--- a/src/backend/caldav/caldav.php
+++ b/src/backend/caldav/caldav.php
@@ -446,7 +446,7 @@ class BackendCalDAV extends BackendDiff {
      * @return string       AS version constant
      */
     public function GetSupportedASVersion() {
-        return ZPush::ASV_14;
+        return ZPush::ASV_161;
     }
 
     /**

--- a/src/backend/carddav/carddav.php
+++ b/src/backend/carddav/carddav.php
@@ -703,7 +703,7 @@ class BackendCardDAV extends BackendDiff implements ISearchProvider {
      * @return string       AS version constant
      */
     public function GetSupportedASVersion() {
-        return ZPush::ASV_14;
+        return ZPush::ASV_161;
     }
 
 

--- a/src/backend/combined/combined.php
+++ b/src/backend/combined/combined.php
@@ -531,7 +531,7 @@ class BackendCombined extends Backend implements ISearchProvider {
      * @return string       AS version constant
      */
     public function GetSupportedASVersion() {
-        $version = ZPush::ASV_14;
+        $version = ZPush::ASV_161;
         foreach ($this->backends as $i => $b) {
             $subversion = $this->backends[$i]->GetSupportedASVersion();
             if ($subversion < $version) {

--- a/src/backend/ldap/ldap.php
+++ b/src/backend/ldap/ldap.php
@@ -564,6 +564,6 @@ class BackendLDAP extends BackendDiff {
      * @return string       AS version constant
      */
     public function GetSupportedASVersion() {
-        return ZPush::ASV_14;
+        return ZPush::ASV_161;
     }
 }

--- a/src/backend/stickynote/stickynote.php
+++ b/src/backend/stickynote/stickynote.php
@@ -553,7 +553,7 @@ class BackendStickyNote extends BackendDiff {
      * @return string       AS version constant
      */
     public function GetSupportedASVersion() {
-        return ZPush::ASV_14;
+        return ZPush::ASV_161;
     }
 
 }


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Changes the AS version to 16.1 for backends, excluding the IMAP backend. 


Does this close any currently open issues?
------------------------------------------
No, it is related to #15 


Any relevant logs, error output, etc?
-------------------------------------
N/A


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: [e.g. iOS]
 - PHP Version: [e.g. 8.2] 
 - Backend for: Mail-in-a-Box, Nextcloud(Carddav/Caldav)
 - and Version: V68, latest

**Smartphone (please complete the following information):**
 - Device: Xiaomi 11T & Redmi Note 7
 - OS: Android: 14 & 10
 - Mail App: GMail 
 - Version: 2024.05.19
