### PR TITLE
Add ICONV_OPTION configuration for iconv's //TRANSLIT and //IGNORE options

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -415,6 +415,7 @@
             'flags'     => DeviceManager::FLD_FLAGS_NONE,
         ),
 */
+    );
 
 /**********************************************************************************
  *  Iconv settings
@@ -431,5 +432,3 @@
  *  https://www.php.net/manual/en/function.iconv.php
  */
     define('ICONV_OPTION', "");
-
-    );

--- a/src/config.php
+++ b/src/config.php
@@ -415,4 +415,21 @@
             'flags'     => DeviceManager::FLD_FLAGS_NONE,
         ),
 */
+
+/**********************************************************************************
+ *  Iconv settings
+ *
+ *  Adds the //TRANSLIT and //IGNORE options for Iconv when converting to UTF8.
+ *
+ *  TRANSLIT attempts to transliterate characters that cannot be converted to the
+ *  target character set, while IGNORE discards them.
+ *  
+ *  These Can be combined as //TRANSLIT//IGNORE to first transliterate, and if that
+ *  fails then discard the characters. 
+ * 
+ *  These options are dependant on the iconv implementation on the system. See
+ *  https://www.php.net/manual/en/function.iconv.php
+ */
+    define('ICONV_OPTION', "");
+
     );

--- a/src/lib/core/zpush.php
+++ b/src/lib/core/zpush.php
@@ -447,6 +447,11 @@ class ZPush {
             }
         }
 
+        // Check Iconv option
+        if (!defined('ICONV_OPTION')) {
+            define('ICONV_OPTION', "");
+        }
+                        
         ZLog::Write(LOGLEVEL_DEBUG, sprintf("Used timezone '%s'", date_default_timezone_get()));
 
         // get the statemachine, which will also try to load the backend.. This could throw errors

--- a/src/lib/utils/utils.php
+++ b/src/lib/utils/utils.php
@@ -1283,7 +1283,7 @@ class Utils {
                 try {
                     $str .= @mb_convert_encoding($val->text, "utf-8", $val->charset);
                 } catch (ValueError $exception) {
-                    $str .= @iconv($val->charset, "utf-8", $val->text);
+                    $str .= @iconv($val->charset, "utf-8" . ICONV_OPTION, $val->text);
                 }
             }
         }


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Provides configuration to set the //TRANSLIT and //IGNORE options


Does this close any currently open issues?
------------------------------------------
#27 


Any relevant logs, error output, etc?
-------------------------------------
N/A


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Ubuntu 22.04
 - PHP Version: 8.0 
 - Backend for: Mail-in-a-Box, Nextcloud(Carddav/Caldav)
 - and Version: V68, latest

**Smartphone (please complete the following information):**
 - Device: Xiaomi 11T & Redmi Note 7
 - OS: Android: 14 & 10
 - Mail App: GMail 
 - Version: 2024.05.26