### PR TITLE
Update Pear Mail to v2.0.0

### DIFF
--- a/src/backend/imap/Mail.php
+++ b/src/backend/imap/Mail.php
@@ -1,32 +1,34 @@
 <?php
 /**
- *  PEAR's Mail:: interface.
+ * PEAR's Mail:: interface.
  *
- * PHP versions 4 and 5
+ * PHP version 5
  *
  * LICENSE:
  *
- * Copyright (c) 2002-2007, Richard Heyes
+ * Copyright (c) 1997-2017, Chuck Hagenbuch & Richard Heyes
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  *
- * o Redistributions of source code must retain the above copyright
- *   notice, this list of conditions and the following disclaimer.
- * o Redistributions in binary form must reproduce the above copyright
- *   notice, this list of conditions and the following disclaimer in the
- *   documentation and/or other materials provided with the distribution.
- * o The names of the authors may not be used to endorse or promote
- *   products derived from this software without specific prior written
- *   permission.
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
  * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
  * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
  * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
@@ -37,9 +39,9 @@
  * @category    Mail
  * @package     Mail
  * @author      Chuck Hagenbuch <chuck@horde.org>
- * @copyright   1997-2010 Chuck Hagenbuch
- * @license     http://opensource.org/licenses/bsd-license.php New BSD License
- * @version     CVS: $Id: Mail.php 307489 2011-01-14 19:06:57Z alec $
+ * @copyright   1997-2017 Chuck Hagenbuch
+ * @license     http://opensource.org/licenses/BSD-3-Clause New BSD License
+ * @version     CVS: $Id$
  * @link        http://pear.php.net/package/Mail/
  */
 
@@ -62,8 +64,7 @@
  * mailers under the PEAR hierarchy, and provides supporting functions
  * useful in multiple mailer backends.
  *
- * @access public
- * @version $Revision: 307489 $
+ * @version $Revision$
  * @package Mail
  */
 class Mail
@@ -72,7 +73,7 @@ class Mail
      * Line terminator used for separating header lines.
      * @var string
      */
-    var $sep = "\r\n";
+    public $sep = "\r\n";
 
     /**
      * Provides an interface for generating Mail:: objects of various
@@ -80,12 +81,13 @@ class Mail
      *
      * @param string $driver The kind of Mail:: object to instantiate.
      * @param array  $params The parameters to pass to the Mail:: object.
+     *
      * @return object Mail a instance of the driver class or if fails a PEAR Error
-     * @access public
      */
-    static function &factory($driver, $params = array())
+    public static function factory($driver, $params = array())
     {
         $driver = strtolower($driver);
+        @include_once 'Mail/' . $driver . '.php';
         $class = 'Mail_' . $driver;
         if (class_exists($class)) {
             $mailer = new $class($params);
@@ -119,10 +121,9 @@ class Mail
      *               containing a descriptive error message on
      *               failure.
      *
-     * @access public
      * @deprecated use Mail_mail::send instead
      */
-    function send($recipients, $headers, $body)
+    public function send($recipients, $headers, $body)
     {
         if (!is_array($headers)) {
             return Mail::raiseError('$headers must be an array');
@@ -159,18 +160,14 @@ class Mail
      * filter is to prevent mail injection attacks.
      *
      * @param array $headers The associative array of headers to sanitize.
-     *
-     * @access private
      */
-    function _sanitizeHeaders(&$headers)
+    protected function _sanitizeHeaders(&$headers)
     {
         foreach ($headers as $key => $value) {
             $headers[$key] =
                 preg_replace('=((<CR>|<LF>|0x0A/%0A|0x0D/%0D|\\n|\\r)\S).*=i',
-                             null, $value);
+                             '', $value);
         }
-
-        return true;
     }
 
     /**
@@ -187,15 +184,15 @@ class Mail
      *               otherwise returns an array containing two
      *               elements: Any From: address found in the headers,
      *               and the plain text version of the headers.
-     * @access private
      */
-    function prepareHeaders($headers)
+    protected function prepareHeaders($headers)
     {
         $lines = array();
         $from = null;
 
         foreach ($headers as $key => $value) {
             if (strcasecmp($key, 'From') === 0) {
+                //include_once 'Mail/RFC822.php';
                 $parser = new Mail_RFC822();
                 $addresses = $parser->parseAddressList($value, 'localhost', false);
                 //if (is_a($addresses, 'PEAR_Error')) {
@@ -249,10 +246,11 @@ class Mail
      *
      * @return mixed An array of forward paths (bare addresses) or a PEAR_Error
      *               object if the address list could not be parsed.
-     * @access private
      */
-    function parseRecipients($recipients)
+    protected function parseRecipients($recipients)
     {
+        //include_once 'Mail/RFC822.php';
+
         // if we're passed an array, assume addresses are valid and
         // implode them before parsing.
         if (is_array($recipients)) {
@@ -262,8 +260,8 @@ class Mail
         // Parse recipients, leaving out all personal info. This is
         // for smtp recipients, etc. All relevant personal information
         // should already be in the headers.
-        $parser = new Mail_RFC822();
-        $addresses = $parser->parseAddressList($recipients, 'localhost', false);
+        $Mail_RFC822 = new Mail_RFC822();
+        $addresses = $Mail_RFC822->parseAddressList($recipients, 'localhost', false);
 
         // If parseAddressList() returned a PEAR_Error object, just return it.
         //if (is_a($addresses, 'PEAR_Error')) {

--- a/src/backend/imap/Mail.php
+++ b/src/backend/imap/Mail.php
@@ -50,10 +50,11 @@
  * Z-Push changes
  *
  * removed PEAR dependency by implementing own raiseError()
+ * Remove duplicated addresses
+ * remove include dependancy
  *
  * Reference implementation used:
- * http://download.pear.php.net/package/Mail-1.2.0.tgz
- * SVN trunk version r333509
+ * https://github.com/pear/Mail/tree/v2.0.0
  *
  *
  */
@@ -93,6 +94,7 @@ class Mail
             $mailer = new $class($params);
             return $mailer;
         } else {
+            // Z-Push change: rasiseError dependancy
             return Mail::raiseError('Unable to find class for driver ' . $driver);
         }
     }
@@ -126,10 +128,12 @@ class Mail
     public function send($recipients, $headers, $body)
     {
         if (!is_array($headers)) {
+            // Z-Push change: rasiseError dependancy
             return Mail::raiseError('$headers must be an array');
         }
 
         $result = $this->_sanitizeHeaders($headers);
+        // Z-Push change: rasiseError dependancy
         //if (is_a($result, 'PEAR_Error')) {
         if ($result === false) {
             return $result;
@@ -192,9 +196,11 @@ class Mail
 
         foreach ($headers as $key => $value) {
             if (strcasecmp($key, 'From') === 0) {
+                // Z-Push change: remove include dependancy
                 //include_once 'Mail/RFC822.php';
                 $parser = new Mail_RFC822();
                 $addresses = $parser->parseAddressList($value, 'localhost', false);
+                // Z-Push change: rasiseError dependancy
                 //if (is_a($addresses, 'PEAR_Error')) {
                 if ($addresses === false) {
                     return $addresses;
@@ -249,6 +255,7 @@ class Mail
      */
     protected function parseRecipients($recipients)
     {
+        // Z-Push change: remove include dependancy
         //include_once 'Mail/RFC822.php';
 
         // if we're passed an array, assume addresses are valid and
@@ -264,6 +271,7 @@ class Mail
         $addresses = $Mail_RFC822->parseAddressList($recipients, 'localhost', false);
 
         // If parseAddressList() returned a PEAR_Error object, just return it.
+        // Z-Push change: rasiseError dependancy
         //if (is_a($addresses, 'PEAR_Error')) {
         if ($addresses === false) {
             return $addresses;
@@ -276,7 +284,7 @@ class Mail
             }
         }
 
-        // Remove duplicated
+        // Z-Push addition: Remove duplicated
         $recipients = array_unique($recipients);
 
         return $recipients;

--- a/src/backend/imap/Mail/mail.php
+++ b/src/backend/imap/Mail/mail.php
@@ -87,18 +87,6 @@ class Mail_mail extends Mail {
         } else {
             $this->_params = $params;
         }
-
-        /* Because the mail() function may pass headers as command
-         * line arguments, we can't guarantee the use of the standard
-         * "\r\n" separator.  Instead, we use the system's native line
-         * separator.
-         * Fixed in PHP 8.0.
-         */
-        if (defined('PHP_EOL') && version_compare(PHP_VERSION, '8.0.0', '<')) {
-            $this->sep = PHP_EOL;
-        } elseif (version_compare(PHP_VERSION, '8.0.0', '<')) {
-            $this->sep = (strpos(PHP_OS, 'WIN') === false) ? "\n" : "\r\n";
-        }
     }
 
     /**

--- a/src/backend/imap/Mail/mail.php
+++ b/src/backend/imap/Mail/mail.php
@@ -51,7 +51,7 @@
  * removed PEAR dependency by implementing own raiseError()
  *
  * Reference implementation used:
- * http://download.pear.php.net/package/Mail-1.4.1.tgz
+ * https://github.com/pear/Mail/tree/v2.0.0
  *
  *
  */
@@ -116,10 +116,12 @@ class Mail_mail extends Mail {
     public function send($recipients, $headers, $body)
     {
         if (!is_array($headers)) {
+            // Z-Push change: rasiseError dependancy
             return Mail_mail::raiseError('$headers must be an array');
         }
 
         $result = $this->_sanitizeHeaders($headers);
+        // Z-Push change: rasiseError dependancy
         //if (is_a($result, 'PEAR_Error')) {
         if ($result === false) {
             return $result;
@@ -144,6 +146,7 @@ class Mail_mail extends Mail {
 
         // Flatten the headers out.
         $headerElements = $this->prepareHeaders($headers);
+        // Z-Push change: rasiseError dependancy
         //if (is_a($headerElements, 'PEAR_Error')) {
         if ($headerElements === false) {
             return $headerElements;
@@ -162,6 +165,7 @@ class Mail_mail extends Mail {
         // If the mail() function returned failure, we need to create a
         // PEAR_Error object and return it instead of the boolean result.
         if ($result === false) {
+            // Z-Push change: rasiseError dependancy
             $result = Mail_mail::raiseError('mail() returned failure');
         }
 

--- a/src/backend/imap/Mail/sendmail.php
+++ b/src/backend/imap/Mail/sendmail.php
@@ -52,7 +52,7 @@
  * removed PEAR dependency by implementing own raiseError()
  *
  * Reference implementation used:
- * http://download.pear.php.net/package/Mail-1.4.1.tgz
+ * https://github.com/pear/Mail/tree/v2.0.0
  *
  *
  */
@@ -144,16 +144,19 @@ class Mail_sendmail extends Mail {
     public function send($recipients, $headers, $body)
     {
         if (!is_array($headers)) {
+            // Z-Push change: rasiseError dependancy
             return Mail_sendmail::raiseError('$headers must be an array');
         }
 
         $result = $this->_sanitizeHeaders($headers);
+        // Z-Push change: rasiseError dependancy
         //if (is_a($result, 'PEAR_Error')) {
         if ($result === false) {
             return $result;
         }
 
         $recipients = $this->parseRecipients($recipients);
+        // Z-Push change: rasiseError dependancy
         //if (is_a($recipients, 'PEAR_Error')) {
         if ($recipients === false) {
             return $recipients;
@@ -161,6 +164,7 @@ class Mail_sendmail extends Mail {
         $recipients = implode(' ', array_map('escapeshellarg', $recipients));
 
         $headerElements = $this->prepareHeaders($headers);
+        // Z-Push change: rasiseError dependancy
         //if (is_a($headerElements, 'PEAR_Error')) {
         if ($headerElements === false) {
             return $headerElements;
@@ -175,11 +179,13 @@ class Mail_sendmail extends Mail {
         }
 
         if (!isset($from)) {
+            // Z-Push change: rasiseError dependancy
             return Mail_sendmail::raiseError('No from address given.');
         } elseif (strpos($from, ' ') !== false ||
                   strpos($from, ';') !== false ||
                   strpos($from, '&') !== false ||
                   strpos($from, '`') !== false) {
+            // Z-Push change: rasiseError dependancy
             return Mail_sendmail::raiseError('From address specified with dangerous characters.');
         }
 
@@ -187,6 +193,7 @@ class Mail_sendmail extends Mail {
 
         $mail = @popen($this->sendmail_path . (!empty($this->sendmail_args) ? ' ' . $this->sendmail_args : '') . " -f$from -- $recipients", 'w');
         if (!$mail) {
+            // Z-Push change: rasiseError dependancy
             return Mail_sendmail::raiseError('Failed to open sendmail [' . $this->sendmail_path . '] for execution.');
         }
 
@@ -203,6 +210,7 @@ class Mail_sendmail extends Mail {
         }
 
         if ($result != 0) {
+            // Z-Push change: rasiseError dependancy
             return Mail_sendmail::raiseError('sendmail returned error code ' . $result,
                                     $result);
         }

--- a/src/backend/imap/Mail/smtp.php
+++ b/src/backend/imap/Mail/smtp.php
@@ -6,7 +6,7 @@
  *
  * LICENSE:
  *
- * Copyright (c) 2010-2017, Chuck Hagenbuch & Jon Parise
+ * Copyright (c) 2010-2021, Chuck Hagenbuch & Jon Parise
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,9 +38,9 @@
  *
  * @category    HTTP
  * @package     HTTP_Request
- * @author      Jon Parise <jon@php.net> 
+ * @author      Jon Parise <jon@php.net>
  * @author      Chuck Hagenbuch <chuck@horde.org>
- * @copyright   2010-2017 Chuck Hagenbuch
+ * @copyright   2010-2021 Chuck Hagenbuch
  * @license     http://opensource.org/licenses/BSD-3-Clause New BSD License
  * @version     CVS: $Id$
  * @link        http://pear.php.net/package/Mail/
@@ -117,6 +117,25 @@ class Mail_smtp extends Mail {
     var $port = 25;
 
     /**
+     * Should STARTTLS connection be used?
+     *
+     * This value may be set to true or false.
+     *
+     * If the value is set to true, the Net_SMTP package will attempt to use
+     * a STARTTLS encrypted connection.
+     *
+     * If the value is set to false, the Net_SMTP package will avoid
+     * a STARTTLS encrypted connection.
+     *
+     * NULL indicates only STARTTLS if $auth is set.
+     *
+     * PEAR/Net_SMTP >= 1.10.0 required.
+     *
+     * @var boolean
+     */
+    var $starttls = null;
+
+    /**
      * Should SMTP authentication be used?
      *
      * This value may be set to true, false or the name of a specific
@@ -166,6 +185,22 @@ class Mail_smtp extends Mail {
     var $debug = false;
 
     /**
+     * Set debug_handler on Net_SMTP
+     *
+     * @var callable $debug_handler
+     */
+    var $debug_handler = null;
+
+    /**
+     * we need the greeting; from it we can extract the authorative name of the mail
+     * server we've really connected to. ideal if we're connecting to a round-robin
+     * of relay servers and need to track which exact one took the email
+     *
+     * @var string
+     */
+    var $greeting = null;
+
+    /**
      * Indicates whether or not the SMTP connection should persist over
      * multiple calls to the send() method.
      *
@@ -188,6 +223,27 @@ class Mail_smtp extends Mail {
      * @var array
      */
     var $socket_options = array();
+
+    /**
+     * SMTP response message
+     *
+     * @var string
+     * @since 1.6.0
+     */
+    var $response = null;
+
+    /**
+     * If the message ends up in the queue, on the recipient server,
+     * the response will be saved here.
+     * Some successfully delivered emails will include a “queued”
+     * notation in the SMTP response, such as "250 OK; queued as 12345".
+     * This indicates that the email was delivered to the recipient
+     * as expected, but may require additional processing before it
+     * lands in the recipient’s inbox.
+     *
+     * @var string
+     */
+    var $queued_as = null;
 
     /**
      * Require verification of SSL certificate used. Default is TRUE.
@@ -217,7 +273,8 @@ class Mail_smtp extends Mail {
      * passed in. It looks for the following parameters:
      *     host                 The server to connect to. Defaults to localhost.
      *     port                 The port to connect to. Defaults to 25.
-     *     auth                 SMTP authentication.  Defaults to none.
+     *     auth                 SMTP authentication. Defaults to none.
+     *     starttls             Should STARTTLS connection be used? No default. PEAR/Net_SMTP >= 1.10.0 required.
      *     username             The username to use for SMTP auth. No default.
      *     password             The password to use for SMTP auth. No default.
      *     localhost            The local hostname / domain. Defaults to localhost.
@@ -225,8 +282,10 @@ class Mail_smtp extends Mail {
      *     verp                 Whether to use VERP or not. Defaults to false.
      *                          DEPRECATED as of 1.2.0 (use setMailParams()).
      *     debug                Activate SMTP debug mode? Defaults to false.
+     *     debug_handler        Set SMTP debug handler function. Defaults to null.
      *     persist              Should the SMTP connection persist?
      *     pipelining           Use SMTP command pipelining
+     *     socket_options       Socket stream_context_create() options.
      *     verify_peer          Require verification of SSL certificate used.
      *     verify_peer_name     Require verification of peer name.
      *     allow_self_signed    Allow self-signed certificates. Requires verify_peer.
@@ -242,11 +301,13 @@ class Mail_smtp extends Mail {
         if (isset($params['host'])) $this->host = $params['host'];
         if (isset($params['port'])) $this->port = $params['port'];
         if (isset($params['auth'])) $this->auth = $params['auth'];
+        if (isset($params['starttls'])) $this->starttls = $params['starttls'];
         if (isset($params['username'])) $this->username = $params['username'];
         if (isset($params['password'])) $this->password = $params['password'];
         if (isset($params['localhost'])) $this->localhost = $params['localhost'];
         if (isset($params['timeout'])) $this->timeout = $params['timeout'];
         if (isset($params['debug'])) $this->debug = (bool)$params['debug'];
+        if (isset($params['debug_handler'])) $this->debug_handler = $params['debug_handler'];
         if (isset($params['persist'])) $this->persist = (bool)$params['persist'];
         if (isset($params['pipelining'])) $this->pipelining = (bool)$params['pipelining'];
         if (isset($params['socket_options'])) $this->socket_options = $params['socket_options'];
@@ -339,7 +400,7 @@ class Mail_smtp extends Mail {
                                     PEAR_MAIL_SMTP_ERROR_FROM);
         }
 
-        $params = null;
+        $params = '';
         if (!empty($this->_extparams)) {
             foreach ($this->_extparams as $key => $val) {
                 $params .= ' ' . $key . (is_null($val) ? '' : '=' . $val);
@@ -371,7 +432,10 @@ class Mail_smtp extends Mail {
 
         /* Send the message's headers and the body as SMTP data. */
         $res = $this->_smtp->data($body, $textHeaders);
-        list(,$args) = $this->_smtp->getResponse();
+
+        list($code, $args) = $this->_smtp->getResponse();
+
+        $this->response = $code . ' ' . $args;
 
         if (preg_match("/ queued as (.*)/", $args, $queued)) {
             $this->queued_as = $queued[1];
@@ -425,7 +489,7 @@ class Mail_smtp extends Mail {
 
         /* Configure the SMTP connection. */
         if ($this->debug) {
-            $this->_smtp->setDebug(true);
+            $this->_smtp->setDebug(true, $this->debug_handler);
         }
 
         /* Attempt to connect to the configured SMTP server. */
@@ -441,14 +505,27 @@ class Mail_smtp extends Mail {
         if ($this->auth) {
             $method = is_string($this->auth) ? $this->auth : '';
 
+            $tls = $this->starttls === false ? false : true;
+
             //if (PEAR::isError($res = $this->_smtp->auth($this->username,
             //                                            $this->password,
-            //                                            $method))) {
+            //                                            $method,
+            //                                            $tls))) {
             if (($res = $this->_smtp->auth($this->username, $this->password, $method)) === false) {
                 $error = $this->_error("$method authentication failure",
                                        $res);
                 $this->_smtp->rset();
                 return Mail_smtp::raiseError($error, PEAR_MAIL_SMTP_ERROR_AUTH);
+            }
+        }
+
+        /* Attempt to establish a TLS encrypted connection. PEAR/Net_SMTP >= 1.10.0 required. */
+        if ($this->starttls && !$this->auth) {
+            $starttls = $this->_smtp->starttls();
+            if (PEAR::isError($starttls)) {
+                return PEAR::raiseError($starttls);
+            } elseif ($starttls === false) {
+                return PEAR::raiseError('STARTTLS failed');
             }
         }
 
@@ -484,6 +561,30 @@ class Mail_smtp extends Mail {
 
         /* We are disconnected if we no longer have an SMTP object. */
         return ($this->_smtp === null);
+    }
+
+    /**
+     * Returns the SMTP response message after sending.
+     *
+     * @return string SMTP response message or NULL.
+     *
+     * @since  1.6.0
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Returns the SMTP response message if includes "queue" after sending.
+     *
+     * @return string SMTP queue message or NULL.
+     *
+     * @since  1.6.0
+     */
+    public function getQueuedAs()
+    {
+        return $this->queued_as;
     }
 
     /**

--- a/src/include/z_RFC822.php
+++ b/src/include/z_RFC822.php
@@ -46,6 +46,20 @@
  * @link        http://pear.php.net/package/Mail/
  */
 
+ /**
+ * Z-Push changes
+ *
+ * removed PEAR dependency by implementing own raiseError()
+ * cast $address to string for explode() for PHP 8.x compatibility
+ * removed public access to num_groups
+ * change indetatation for parseAddressList
+ *
+ * Reference implementation used:
+ * https://github.com/pear/Mail/tree/v2.0.0
+ *
+ *
+ */
+
 /**
  * RFC 822 Email address list validation Utility
  *
@@ -70,7 +84,6 @@
  * @license BSD
  * @package Mail
  */
-
 class Mail_RFC822 {
 
     /**
@@ -124,6 +137,7 @@ class Mail_RFC822 {
     /**
      * The number of groups that have been found in the address list.
      * @var integer $num_groups
+     * // Z-Push removal: access public
      */
     var $num_groups = 0;
 
@@ -173,6 +187,7 @@ class Mail_RFC822 {
      */
     public function parseAddressList($address = null, $default_domain = null, $nest_groups = null, $validate = null, $limit = null)
     {
+        // Z-Push Change: indentation
         if (version_compare(PHP_VERSION, '8.0.0', '<')) {
             if (!isset($this) || !isset($this->mailRFC822)) {
                 $warn = "Calling non-static methods statically is no longer supported since PHP 8";
@@ -202,6 +217,7 @@ class Mail_RFC822 {
         while ($this->address = $this->_splitAddresses($this->address));
 
         if ($this->address === false || isset($this->error)) {
+            // Z-Push change rasiseError dependancy
             //require_once 'PEAR.php';
             return $this->raiseError($this->error);
         }
@@ -212,6 +228,7 @@ class Mail_RFC822 {
             $valid = $this->_validateAddress($address);
 
             if ($valid === false || isset($this->error)) {
+                // Z-Push change: rasiseError dependancy
                 //require_once 'PEAR.php';
                 return $this->raiseError($this->error);
             }
@@ -252,6 +269,7 @@ class Mail_RFC822 {
         }
 
         // Split the string based on the above ten or so lines.
+        // Z-Push change: (string) cast
         $parts  = explode($split_char, (string) $address);
         $string = $this->_splitCheck($parts, $split_char);
 
@@ -284,6 +302,7 @@ class Mail_RFC822 {
 
         // Remove the now stored address from the initial line, the +1
         // is to account for the explode character.
+        // Z-Push change: (string) cast
         $address = trim(substr((string) $address, strlen($string) + 1));
 
         // If the next char is a comma and this was a group, then
@@ -313,6 +332,7 @@ class Mail_RFC822 {
     protected function _isGroup($address)
     {
         // First comma not in quotes, angles or escaped:
+        // Z-Push change: (string) cast
         $parts  = explode(',', (string) $address);
         $string = $this->_splitCheck($parts, ',');
 

--- a/src/include/z_RFC822.php
+++ b/src/include/z_RFC822.php
@@ -60,7 +60,8 @@
  * How do I use it?
  *
  * $address_string = 'My Group: "Richard" <richard@localhost> (A comment), ted@example.com (Ted Bloggs), Barney;';
- * $structure = Mail_RFC822::parseAddressList($address_string, 'example.com', true)
+ * $parser = new Mail_RFC822();
+ * $structure = $parser->parseAddressList($address_string, 'example.com', true);
  * print_r($structure);
  *
  * @author  Richard Heyes <richard@phpguru.org>
@@ -172,9 +173,13 @@ class Mail_RFC822 {
      */
     public function parseAddressList($address = null, $default_domain = null, $nest_groups = null, $validate = null, $limit = null)
     {
-        if (!isset($this) || !isset($this->mailRFC822)) {
-            $obj = new Mail_RFC822($address, $default_domain, $nest_groups, $validate, $limit);
-            return $obj->parseAddressList();
+        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+            if (!isset($this) || !isset($this->mailRFC822)) {
+                $warn = "Calling non-static methods statically is no longer supported since PHP 8";
+                trigger_error($warn, E_USER_NOTICE);
+                $obj = new Mail_RFC822($address, $default_domain, $nest_groups, $validate, $limit);
+                return $obj->parseAddressList();
+            }
         }
 
         if (isset($address))        $this->address        = $address;
@@ -229,6 +234,9 @@ class Mail_RFC822 {
      */
     protected function _splitAddresses($address)
     {
+        $is_group = false;
+        $split_char = ',';
+
         if (!empty($this->limit) && count($this->addresses) == $this->limit) {
             return '';
         }
@@ -439,6 +447,7 @@ class Mail_RFC822 {
      */
     protected function _validateAddress($address)
     {
+        $structure = null;
         $is_group = false;
         $addresses = array();
 
@@ -479,7 +488,7 @@ class Mail_RFC822 {
         }
 
         // Trim the whitespace from all of the address strings.
-        array_map('trim', $addresses);
+        $addresses = array_map('trim', $addresses);
 
         // Validate each mailbox.
         // Format could be one of: name <geezer@domain.com>
@@ -616,6 +625,7 @@ class Mail_RFC822 {
         $phrase  = '';
         $comment = '';
         $comments = array();
+        $addr_spec = null;
 
         // Catch any RFC822 comments and store them separately.
         $_mailbox = $mailbox;
@@ -773,6 +783,7 @@ class Mail_RFC822 {
     {
         // Note the different use of $subdomains and $sub_domains
         $subdomains = explode('.', $domain);
+        $sub_domains = array();
 
         while (count($subdomains) > 0) {
             $sub_domains[] = $this->_splitCheck($subdomains, '.');


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates Z-Push's implementation of Pear/Mail to v2.0.0


Does this close any currently open issues?
------------------------------------------
#35 


Any relevant logs, error output, etc?
-------------------------------------
N/A


Where has this been tested?
---------------------------
To be tested thoroughly still
