### PR TITLE
Update version for autodiscover subdirectory

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -28,11 +28,16 @@ if (!defined("ZPUSH_VERSION")) {
     $branch = trim(exec("hash git 2>/dev/null && cd $path >/dev/null 2>&1 && git branch --no-color 2>/dev/null | sed -e '/^[^*]/d' -e \"s/* \(.*\)/\\1/\""));
     $version = exec("hash git 2>/dev/null && cd $path >/dev/null 2>&1 && git describe  --always 2>/dev/null");
     $file = dirname(realpath($_SERVER['SCRIPT_FILENAME'])) . '/version';
+    $fileparent = dirname(realpath($_SERVER['SCRIPT_FILENAME'])) . '/../version';
     if ($branch && $version) {
         define("ZPUSH_VERSION", $branch .'-'. $version);
     }
     elseif (file_exists($file)) {
         $line = fgets(fopen($file, 'r'));
+        define("ZPUSH_VERSION", $line);
+    }
+    elseif (file_exists($fileparent)) {
+        $line = fgets(fopen($fileparent, 'r'));
         define("ZPUSH_VERSION", $line);
     }
     else {


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the version from the version file when calling from a subdirectory like autodiscover. 


Does this close any currently open issues?
------------------------------------------
#65 


Any relevant logs, error output, etc?
-------------------------------------
...


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Ubuntu 22.04
 - PHP Version: 8.0 
 - Backend for: Mail-in-a-Box, Nextcloud(Carddav/Caldav)
 - and Version: V68, latest

**Smartphone (please complete the following information):**
 - Device: Xiaomi 11T & Redmi Note 7
 - OS: Android: 14 & 10
 - Mail App: GMail 
 - Version: 2024.05.26
