### PR TITLE
Fixed Folders created on Outlook 2021 get duplicated

### DIFF
--- a/src/lib/default/diffbackend/diffstate.php
+++ b/src/lib/default/diffbackend/diffstate.php
@@ -227,7 +227,7 @@ class DiffState implements IChanges {
     protected function updateState($type, $change) {
         // Change can be a change or an add
         if($type == "change") {
-            for($i=0; $i < count($this->syncstate); $i++) {
+            for($i=0; $i < count((array)$this->syncstate); $i++) {
                 if($this->syncstate[$i]["id"] == $change["id"]) {
                     $this->syncstate[$i] = $change;
                     return;
@@ -236,7 +236,7 @@ class DiffState implements IChanges {
             // Not found, add as new
             $this->syncstate[] = $change;
         } else {
-            for($i=0; $i < count($this->syncstate); $i++) {
+            for($i=0; $i < count((array)$this->syncstate); $i++) {
                 // Search for the entry for this item
                 if($this->syncstate[$i]["id"] == $change["id"]) {
                     if($type == "flags") {


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes outlook issue 

Cast array for updateState() loops in difstate.php


Does this close any currently open issues?
------------------------------------------
#68 


Any relevant logs, error output, etc?
-------------------------------------
see #68 


Where has this been tested?
---------------------------
See #68 