### PR TITLE
fix: error `PHP message: PHP Fatal error:  Uncaught Error: Attempt to assign property "body" on null`

### DIFF
--- a/src/include/mimeDecode.php
+++ b/src/include/mimeDecode.php
@@ -404,6 +404,7 @@ class Mail_mimeDecode
                     }
                     // if there is no explicit charset, then don't try to convert to default charset, and make sure that only text mimetypes are converted
                     $charset = (isset($return->ctype_parameters['charset']) && ((isset($return->ctype_primary) && $return->ctype_primary == 'text') || !isset($return->ctype_primary)) ) ? $return->ctype_parameters['charset'] : '';
+                    $part = new stdClass();
                     $part->body = ($this->_decode_bodies ? $this->_decodeBody($body, $content_transfer_encoding['value'], $charset, false) : $body);
                     $ctype = explode('/', strtolower($content_type['value']));
                     $part->ctype_parameters['name'] = 'smime.p7m';


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix a PHP Fatal error


Any relevant logs, error output, etc?
-------------------------------------
    PHP message: PHP Fatal error:  Uncaught Error: Attempt to assign property "body" on null in /usr/local/lib/z-push/include/mimeDecode.php:407


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS:  Ubuntu
 - PHP Version: 8.2
 - Backend for: Mail-in-a-Box
 - Version: v68

**Smartphone (please complete the following information):**
 - Device: iPhone 8
 - OS: iOS 17.1
 - Mail App: Apple Mail
