### PR TITLE
Update mime_encode.php

### DIFF
--- a/src/backend/imap/mime_encode.php
+++ b/src/backend/imap/mime_encode.php
@@ -204,7 +204,7 @@ function build_mime_message($message) {
                 $mimeHeaders['content_type'] = $new_value;
                 break;
             case 'content-transfer-encoding':
-                if (strcasecmp($value, "base64") == 0 || strcasecmp($value, "binary") == 0) {
+                if (is_string($value) && (strcasecmp($value, "base64") == 0 || strcasecmp($value, "binary") == 0)) {
                     $mimeHeaders['encoding'] = "base64";
                 }
                 else {


### PR DESCRIPTION
fix: error `PHP message: PHP Fatal error:  Uncaught TypeError: strcasecmp(): Argument #1 ($string1) must be of type string`

There is `is_array($value)` in default case, so, it needs `is_string` to detect.