### PR TITLE
Imap - Additional recevied mail header for remote device IP address

### DIFF
--- a/src/backend/imap/config.php
+++ b/src/backend/imap/config.php
@@ -217,3 +217,7 @@ define('IMAP_MEETING_USE_CALDAV', false);
 
 // Specify Which Charset the IMAP Search is going to use, Default is 'UTF-8' but you could use 'US-ASCII'
 define('IMAP_SEARCH_CHARSET', 'UTF-8');
+
+// Use additional recevied mail header for remote device IP address. Example: 
+// received: from 1.2.3.123 by hostname (Z-Push); Mon, 01 Jan 2024 00:00:00 +1000
+define('IMAP_RECEIVED', false);

--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -265,6 +265,9 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
 
         $this->setReturnPathValue($message->headers, $fromaddr);
 
+        if (defined('IMAP_RECEIVED') && IMAP_RECEIVED)
+            $message->headers["received"] = "from " . Request::GetRemoteAddr() . " by " . gethostname() . " (Z-Push); " . $message->headers["date"];
+
         $finalBody = "";
         $finalHeaders = array();
 


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds an option to include the remote device IP in a received header for Imap Backend

Example
received: from 1.2.3.123 by hostname (Z-Push); Mon, 01 Jan 2024 00:00:00 +1000


Does this close any currently open issues?
------------------------------------------
#61 


Any relevant logs, error output, etc?
-------------------------------------
#61 

Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Ubuntu
 - PHP Version: 8.0 
 - Backend for: Mail-in-a-Box
 - and Version: v68

**Smartphone (please complete the following information):**
 - Device: Xiaomi 11T
 - OS: Android
 - Mail App GMail
 - Version latest
