### PR TITLE
fixed #88 PGP and S/MIME encryption

### DIFF
--- a/src/include/mimeDecode.php
+++ b/src/include/mimeDecode.php
@@ -354,7 +354,7 @@ class Mail_mimeDecode
 
                     $default_ctype = (strtolower($content_type['value']) === 'multipart/digest') ? 'message/rfc822' : 'text/plain';
 
-                    $parts = $this->_boundarySplit($body, $content_type['other']['boundary'], strtolower($content_type['value']) === 'multipart/signed'));
+                    $parts = $this->_boundarySplit($body, $content_type['other']['boundary'], strtolower($content_type['value']) === 'multipart/signed');
                     for ($i = 0; $i < count($parts); $i++) {
                         list($part_header, $part_body) = $this->_splitBodyHeader($parts[$i]);
                         $part = $this->_decode($part_header, $part_body, $default_ctype);

--- a/src/include/mimeDecode.php
+++ b/src/include/mimeDecode.php
@@ -330,25 +330,12 @@ class Mail_mimeDecode
         if (isset($content_type)) {
             switch (strtolower($content_type['value'])) {
                 case 'text/plain':
-                    $encoding = isset($content_transfer_encoding) ? $content_transfer_encoding['value'] : '7bit';
-                    $charset = isset($return->ctype_parameters['charset']) ? $return->ctype_parameters['charset'] : $this->_charset;
-                    $this->_include_bodies ? $return->body = ($this->_decode_bodies ? $this->_decodeBody($body, $encoding, $charset, true) : $body) : null;
-                    break;
-
                 case 'text/html':
                     $encoding = isset($content_transfer_encoding) ? $content_transfer_encoding['value'] : '7bit';
                     $charset = isset($return->ctype_parameters['charset']) ? $return->ctype_parameters['charset'] : $this->_charset;
                     $this->_include_bodies ? $return->body = ($this->_decode_bodies ? $this->_decodeBody($body, $encoding, $charset, true) : $body) : null;
                     break;
-
-                case 'multipart/signed': // PGP
-                    $parts = $this->_boundarySplit($body, $content_type['other']['boundary'], true);
-                    $return->parts['msg_body'] = $parts[0];
-                    list($part_header, $part_body) = $this->_splitBodyHeader($parts[1]);
-                    $return->parts['sig_hdr'] = $part_header;
-                    $return->parts['sig_body'] = $part_body;
-                    break;
-
+                
                 case 'multipart/encrypted': // #190 encrypted parts will be treated as normal ones
                 case 'multipart/parallel':
                 case 'multipart/appledouble': // Appledouble mail
@@ -367,7 +354,7 @@ class Mail_mimeDecode
 
                     $default_ctype = (strtolower($content_type['value']) === 'multipart/digest') ? 'message/rfc822' : 'text/plain';
 
-                    $parts = $this->_boundarySplit($body, $content_type['other']['boundary']);
+                    $parts = $this->_boundarySplit($body, $content_type['other']['boundary'], strtolower($content_type['value']) === 'multipart/signed'));
                     for ($i = 0; $i < count($parts); $i++) {
                         list($part_header, $part_body) = $this->_splitBodyHeader($parts[$i]);
                         $part = $this->_decode($part_header, $part_body, $default_ctype);


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3

What does this implement/fix? Explain your changes.
---------------------------------------------------
1. There is duplicate code in case 'text/plain' and case 'text/html' in the switch statement.
2. The case 'multipart/signed' creates a structurally distinct $return->parts that doesn't actually reference any of the three string keys elsewhere, which, combined with the duplicate code above, may be part of the unfinished work left over from a commit 7 years ago. The key to 'multipart/signed' is that the $this->_boundarySplit function is called with the parameter $eatline specified as true.

I looked at an email containing a PGP signature and there is no other special structure. So I believe that the separate case for multipart/signed was added in the commit 7 years ago, possibly for experimental and testing purposes, such as trying to verify PGP signatures. But it wasn't done and it wasn't tested.

With a simple modification, z-push can synchronize related PGP messages with the client without interrupting the synchronization or reporting errors. Perhaps the current simple modification does not have sufficient support for PGP mail (Mail.app for iOS does not support PGP, so I am not yet sure that the signature information is correctly synchronized with the client). But in principle, this modification doesn't break anything. 

Does this close any currently open issues?
------------------------------------------
#88 

Where has this been tested?
---------------------------
**Server:**
 - OS: Ubuntu
 - PHP Version: 8
 - Backend for: Mail-in-a-Box
 - Version: v69b

**Smartphone:**
 - Device: iPhone SE
 - OS:  iOS 17.5.1
 - Mail App: Mail.app
 - Version: 
