### PR TITLE
Imap backend 16.1 - Update AS version constant to 16.1

### DIFF
--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -1962,7 +1962,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
      * @return string       AS version constant
      */
     public function GetSupportedASVersion() {
-        return ZPush::ASV_14;
+        return ZPush::ASV_161;
     }
 
 


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This enables AS 16.1 for Imap.

Note that work still needs to be done on Importing Drafts from the phone.


Does this close any currently open issues?
------------------------------------------
#15 


