### PR TITLE
Radicale ignore vcard getcontenttype if Address Book collection

### DIFF
--- a/src/include/z_carddav.php
+++ b/src/include/z_carddav.php
@@ -657,9 +657,10 @@ EOFXMLGETXMLVCARD;
 
             foreach ($xml->response as $response) {
                 if (isset($response->propstat)) {
-                    if ((strlen($this->url_vcard_extension) > 0 && preg_match('/'.$this->url_vcard_extension.'/', $response->href) &&
+                    if ((((strlen($this->url_vcard_extension) > 0 && preg_match('/'.$this->url_vcard_extension.'/', $response->href)) 
+                        || preg_match('/vcard/', $response->propstat->prop->getcontenttype)) &&
                         !(isset($response->propstat->prop->resourcetype) && isset($response->propstat->prop->resourcetype->addressbook)))
-                        || preg_match('/vcard/', $response->propstat->prop->getcontenttype) || isset($response->propstat->prop->{'address-data'}) || isset($response->propstat->prop->{'addressbook-data'})) {
+                        || isset($response->propstat->prop->{'address-data'}) || isset($response->propstat->prop->{'addressbook-data'})) {
                         // It's a vcard
                         $id = basename($response->href);
                         $id = str_replace($this->url_vcard_extension, null, $id);


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
As per #67 and https://github.com/Kozea/Radicale/issues/386#issuecomment-2295112906 this is to ignore vcard content-type for addressbooks so that Radicale can work.

Does this close any currently open issues?
------------------------------------------
#67 