### PR TITLE
Wrong encoding, conversion from "unicode-1-1-utf-7"

### DIFF
--- a/src/lib/utils/utils.php
+++ b/src/lib/utils/utils.php
@@ -1265,6 +1265,9 @@ class Utils {
         $str = "";
         $striso2022jp = "";
         foreach (@imap_mime_header_decode($nonencstr) as $val) {
+            if ($val->charset == "unicode-1-1-utf-7") {
+                $val->charset = "utf-7";
+            }
             if (is_null($charset)) {
                 $charset = strtolower($val->charset);
             }


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
change charset to utf-7 for unicode-1-1-utf-7


Does this close any currently open issues?
------------------------------------------
#90 


Any relevant logs, error output, etc?
-------------------------------------
26/07/2024 03:05:21 [183171] [WARN][@.] /usr/local/lib/z-push/lib/utils/utils.php:1284 iconv(): Wrong encoding, conversion from "unicode-1-1-utf-7" to "utf-8" is not allowed (2)