### PR TITLE
fix PHP 8.0 error ("" < -1) as there is no automatic cast anymore Syn…

### DIFF
--- a/src/lib/syncobjects/syncobject.php
+++ b/src/lib/syncobjects/syncobject.php
@@ -528,8 +528,8 @@ abstract class SyncObject extends Streamer {
                                 ZLog::Write(LOGLEVEL_WARN, sprintf("SyncObject->Check(): Unmet condition in object from type %s: parameter '%s' can not be compared, as the comparable is not set. Check failed!", $objClass, $v[self::STREAMER_VAR]));
                                 return false;
                             }
-                            if ( ($rule == self::STREAMER_CHECK_CMPHIGHER && $this->{$v[self::STREAMER_VAR]} < $cmp) ||
-                                 ($rule == self::STREAMER_CHECK_CMPLOWER  && $this->{$v[self::STREAMER_VAR]} > $cmp)
+                            if ( ($rule == self::STREAMER_CHECK_CMPHIGHER && (float)$this->{$v[self::STREAMER_VAR]} < $cmp) ||
+                                 ($rule == self::STREAMER_CHECK_CMPLOWER  && (float)$this->{$v[self::STREAMER_VAR]} > $cmp)
                                 ) {
 
                                 ZLog::Write(LOGLEVEL_WARN, sprintf("SyncObject->Check(): Unmet condition in object from type %s: parameter '%s' is %s than '%s'. Check failed!",


### PR DESCRIPTION
…cObject->Check(): Unmet condition in object from type SyncProvisioning: parameter maxattsize is LOWER than -1. Check failed!

Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
It restores the previous PHP versions behavior, that ("" < -1) === false, by an explicit cast to (float)


Does this close any currently open issues?
------------------------------------------
...


Any relevant logs, error output, etc?
-------------------------------------
Unmet condition in object from type SyncProvisioning: parameter maxattsize is LOWER than -1. Check failed!


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: iOS and Android
 - PHP Version: 8.4
 - Backend for: EGroupware using diffbackend
 - and Version: Z-Push version 2.5.0

**Smartphone (please complete the following information):**
 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Mail App [e.g. GMail, Apple Mail] 
 - Version [e.g. 22]
