### PR TITLE
fixstates skip IStateMachine::BACKENDSTORAGE for delete

### DIFF
--- a/src/lib/utils/zpushadmin.php
+++ b/src/lib/utils/zpushadmin.php
@@ -1019,6 +1019,9 @@ class ZPushAdmin {
                 if ($obsoleteState['type'] === IStateMachine::DEVICEDATA)
                     continue;
 
+                if ($obsoleteState['type'] === IStateMachine::BACKENDSTORAGE)
+                    continue;
+                
                 if (!in_array($obsoleteState['uuid'], $knownUuids)) {
                     if (is_numeric($obsoleteState['counter']))
                         $obsoleteState['counter']++;


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
z-push-admin fixstates was deleting states of type IStateMachine::BACKENDSTORAGE as it doesn't store with a uuid

Does this close any currently open issues?
------------------------------------------
It might solve #92 


Any relevant logs, error output, etc?
-------------------------------------
11:08:26 Checking for unreferenced (obsolete) state files: Processed: 1123 - Deleted: 7

