### PR TITLE
fixed find problem on ios 18. It searched for a message without a fol…

### DIFF
--- a/src/lib/request/find.php
+++ b/src/lib/request/find.php
@@ -175,8 +175,9 @@ class Find extends RequestProcessor {
             if ($searchtotal > 0) {
                 foreach ($rows as $u) {
                     // fetch the SyncObject for this result
-                    $message = self::$backend->Fetch(false, $u['longid'], $cpo);
-                    $mfolderid = self::$deviceManager->GetFolderIdForBackendId(bin2hex($message->ParentSourceKey));
+										list($longfolderid, $uid) = Utils::SplitMessageId($u['longid']);
+										$folderid = self::$deviceManager->GetFolderIdForBackendId($u['folderid']);
+                    $message = self::$backend->Fetch($folderid, $uid, $cpo);
 
                     self::$encoder->startTag(SYNC_FIND_RESULT);
                     self::$encoder->startTag(SYNC_FOLDERTYPE);
@@ -184,7 +185,7 @@ class Find extends RequestProcessor {
                     self::$encoder->endTag();
 
                     self::$encoder->startTag(SYNC_SERVERENTRYID);
-                    self::$encoder->content($mfolderid . ":" . $u['serverid']);
+                    self::$encoder->content($folderid . ":" . $u['serverid']);
                     self::$encoder->endTag();
                     self::$encoder->startTag(SYNC_FOLDERID);
                     self::$encoder->content($cpo->GetRawFindFolderId());


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request replaces my old pull request implementing the Find command. I took the base code and tested it but ran into an issue:

The Find command implementation:

https://github.com/Z-Hub/Z-Push/blob/af25a2169a50d6e05a5916d1e8b2b6cd17011c98/src/lib/request/find.php#L178

Didn't pass the folderId to the backend Fetch() method:

https://github.com/Z-Hub/Z-Push/blob/af25a2169a50d6e05a5916d1e8b2b6cd17011c98/src/lib/default/diffbackend/diffbackend.php#L129

The message can't be found that way. I also pass the server ID and not the long ID as kopano is the only backend that splits the long ID:

https://github.com/Z-Hub/Z-Push/blob/07f60c76cb46d0c63fc18ac387476b304d379087/src/backend/kopano/kopano.php#L750

The BackendDiff class doesn't do this.

Does this close any currently open issues?
------------------------------------------
Not sure. But it might close https://github.com/Z-Hub/Z-Push/issues/141



Any relevant logs, error output, etc?
-------------------------------------
...


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: debian
 - PHP Version: 8.3
 - Backend for: Group-Office
 - and Version: current development branch

**Smartphone (please complete the following information):**
 - Device: iPhone 13
 - OS: iOS 18
 - Mail App Apple mail
