### PR TITLE
Fixed Find command to work with iPhone running ios 18.4.1

### DIFF
--- a/src/lib/request/find.php
+++ b/src/lib/request/find.php
@@ -7,211 +7,218 @@
  */
 
 class Find extends RequestProcessor {
-    /**
-     * Handles the Find command.
-     *
-     * @param int $commandCode
-     *
-     * @return bool
-     */
-    public function Handle($commandCode) {
-        $cpo = new ContentParameters();
-        if (!self::$decoder->getElementStartTag(SYNC_FIND_FIND)) {
-            return false;
-        }
 
-        if (!self::$decoder->getElementStartTag(SYNC_FIND_SEARCHID)) {
-            return false;
-        }
-        $searchId = self::$decoder->getElementContent();
-        $cpo->SetFindSearchId($searchId);
-        if (!self::$decoder->getElementEndTag()) { // SYNC_FIND_SEARCHID
-            return false;
-        }
+	/**
+	 * Handles the Search command
+	 *
+	 * @param int       $commandCode
+	 *
+	 * @access public
+	 * @return boolean
+	 */
+	public function Handle($commandCode) {
 
-        if (!self::$decoder->getElementStartTag(SYNC_FIND_EXECUTESEARCH)) {
-            return false;
-        }
+		$searchrange = '0';
 
-        if (self::$decoder->getElementStartTag(SYNC_FIND_MAILBOXSEARCHCRITERION)) {
-            $searchname = ISearchProvider::SEARCH_MAILBOX;
-            if (!self::$decoder->getElementStartTag(SYNC_FIND_QUERY)) {
-                return false;
-            }
+		$cpo = new ContentParameters();
 
-            if (self::$decoder->getElementStartTag(SYNC_FOLDERTYPE)) {
-                $folderType = self::$decoder->getElementContent();
-                $cpo->SetFindFolderType($folderType);
-                if (!self::$decoder->getElementEndTag()) { // SYNC_FOLDERTYPE
-                    return false;
-                }
-            }
+		if(!self::$decoder->getElementStartTag(SYNC_FIND_FIND)) {
+			ZLog::Write(LOGLEVEL_DEBUG, "ERROR: No find tag");
+			return false;
+		}
 
-            if (self::$decoder->getElementStartTag(SYNC_FOLDERID)) {
-                $folderId = self::$decoder->getElementContent();
-                $cpo->SetFindFolderId($folderId);
-                $cpo->SetRawFindFolderId($folderId);
-                if (!self::$decoder->getElementEndTag()) { // SYNC_FOLDERID
-                    return false;
-                }
-            }
+		if(!self::$decoder->getElementStartTag(SYNC_FIND_SEARCHID))
+			return false;
+		$searchId = self::$decoder->getElementContent();
+		$cpo->SetFindSearchId($searchId);
 
-            if (self::$decoder->getElementStartTag(SYNC_FIND_FREETEXT)) {
-                $freeText = self::$decoder->getElementContent();
-                $cpo->SetFindFreeText($freeText);
-                if (!self::$decoder->getElementEndTag()) { // SYNC_FIND_FREETEXT
-                    return false;
-                }
-            }
+		ZLog::Write(LOGLEVEL_DEBUG, "SearchId: $searchId");
+		if(!self::$decoder->getElementEndTag())
+			return false;
 
-            if (!self::$decoder->getElementEndTag()) { // SYNC_FIND_QUERY
-                return false;
-            }
+		if(!self::$decoder->getElementStartTag(SYNC_FIND_EXECUTESEARCH))
+			return false;
 
-            $deeptraversal = false;
-            if (self::$decoder->getElementStartTag(SYNC_FIND_OPTIONS)) {
-                WBXMLDecoder::ResetInWhile("findOptions");
-                while (WBXMLDecoder::InWhile("findOptions")) {
-                    if (self::$decoder->getElementStartTag(SYNC_FIND_RANGE)) {
-                        $findrange = self::$decoder->getElementContent();
-                        $cpo->SetFindRange($findrange);
-                        if (!self::$decoder->getElementEndTag()) {
-                            return false;
-                        }
-                    }
+		if(!self::$decoder->getElementStartTag(SYNC_FIND_MAILBOXSEARCHCRITERION))
+			return false;
 
-                    if (self::$decoder->getElementStartTag(SYNC_FIND_DEEPTRAVERSAL)) {
-                        $deeptraversal = true;
-                        if (($dam = self::$decoder->getElementContent()) !== false) {
-                            $deeptraversal = true;
-                            if (!self::$decoder->getElementEndTag()) {
-                                return false;
-                            }
-                        }
-                    }
-                    $e = self::$decoder->peek();
-                    if ($e[EN_TYPE] == EN_TYPE_ENDTAG) {
-                        self::$decoder->getElementEndTag();
+		if(!self::$decoder->getElementStartTag(SYNC_FIND_QUERY))
+			return false;
 
-                        break;
-                    }
-                }
-            }
-            $cpo->SetFindDeepTraversal($deeptraversal);
+		if (self::$decoder->getElementStartTag(SYNC_FOLDERTYPE)) {
+			$searchclass = self::$decoder->getElementContent();
 
-            if (!self::$decoder->getElementEndTag()) { // SYNC_FIND_MAILBOXSEARCHCRITERION
-                return false;
-            }
-        }
+			ZLog::Write(LOGLEVEL_DEBUG, "FolderType: $searchclass");
+			$cpo->SetSearchClass($searchclass);
+			if(!self::$decoder->getElementEndTag()) {// SYNC_FOLDERTYPE
+				ZLog::Write(LOGLEVEL_DEBUG, "ERROR: No end tag");
+				return false;
+			}
+		}
 
-        if (self::$decoder->getElementStartTag(SYNC_FIND_GALSEARCHCRITERION)) {
-            $searchname = ISearchProvider::SEARCH_GAL;
-            $galSearchCriterion = self::$decoder->getElementContent();
-            if (!self::$decoder->getElementEndTag()) { // SYNC_FIND_GALSEARCHCRITERION
-                return false;
-            }
-        }
+		if (self::$decoder->getElementStartTag(SYNC_FOLDERID)) {
+			$searchfolderid = self::$decoder->getElementContent();
+			ZLog::Write(LOGLEVEL_DEBUG, "FolderId: $searchfolderid");
+			$cpo->SetSearchFolderid($searchfolderid);
+			if(!self::$decoder->getElementEndTag()) {// SYNC_FOLDERTYPE
+				ZLog::Write(LOGLEVEL_DEBUG, "ERROR: No end tag");
+				return false;
+			}
+		}
 
-        if (!self::$decoder->getElementEndTag()) { // SYNC_FIND_EXECUTESEARCH
-            return false;
-        }
+		if (self::$decoder->getElementStartTag(SYNC_FIND_FREETEXT)) {
+			$searchfreetext = self::$decoder->getElementContent();
 
-        if (!self::$decoder->getElementEndTag()) { // SYNC_FIND_FIND
-            return false;
-        }
+			ZLog::Write(LOGLEVEL_DEBUG, "FreeText: $searchfreetext");
+			$cpo->SetFindFreeText($searchfreetext);
+			if(!self::$decoder->getElementEndTag()) {// SYNC_FOLDERTYPE
+				ZLog::Write(LOGLEVEL_DEBUG, "ERROR: No end tag");
+				return false;
+			}
+		}
 
-        // get SearchProvider
-        $searchprovider = ZPush::GetBackend()->GetSearchProvider();
-        $findstatus = SYNC_FINDSTATUS_SUCCESS;
+		if(!self::$decoder->getElementEndTag()) // SYNC_SEARCH_QUERY
+			return false;
 
-        if (!isset($searchname)) {
-            $findstatus = SYNC_FINDSTATUS_INVALIDREQUEST;
-        }
 
-        self::$encoder->startWBXML();
-        self::$encoder->startTag(SYNC_FIND_FIND);
+		if(self::$decoder->getElementStartTag(SYNC_FIND_OPTIONS)) {
 
-        self::$encoder->startTag(SYNC_FIND_STATUS);
-        self::$encoder->content($findstatus);
-        self::$encoder->endTag();
+			if (self::$decoder->getElementStartTag(SYNC_FIND_RANGE)) {
+				$searchrange = self::$decoder->getElementContent();
+				ZLog::Write(LOGLEVEL_DEBUG, "Range: $searchrange");
+				$cpo->SetFindRange($searchrange);
+				if (!self::$decoder->getElementEndTag())
+					return false;
+			}
 
-        if ($findstatus == SYNC_FINDSTATUS_SUCCESS) {
-            $status = SYNC_FINDSTATUS_SUCCESS;
+			if (self::$decoder->getElementStartTag(SYNC_FIND_DEEPTRAVERSAL)) {
+				$deeptraversal = true;
+				if (($dam = self::$decoder->getElementContent()) !== false) {
+					$deeptraversal = true;
+					if (!self::$decoder->getElementEndTag()) {
+						return false;
+					}
+				}
+				$cpo->SetFindDeepTraversal($deeptraversal);
+			}
+			if (!self::$decoder->getElementEndTag())
+				return false;
+		}
 
-            try {
-                if ($searchname == ISearchProvider::SEARCH_GAL) {
-                    // get search results from the searchprovider
-                    $rows = $searchprovider->GetGALSearchResults($searchquery, $searchrange, $searchpicture);
-                }
-                elseif ($searchname == ISearchProvider::SEARCH_MAILBOX) {
-                    $backendFolderId = self::$deviceManager->GetBackendIdForFolderId($cpo->GetFindFolderid());
-                    $cpo->SetFindFolderid($backendFolderId);
-                    $rows = $searchprovider->GetMailboxSearchResults($cpo);
-                }
-            }
-            catch (StatusException $stex) {
-                $storestatus = $stex->getCode();
-            }
+		if(!self::$decoder->getElementEndTag()) // MailBoxSearchCriterion
+			return false;
 
-            self::$encoder->startTag(SYNC_FIND_RESPONSE);
+		if(!self::$decoder->getElementEndTag()) // ExecuteSearch
+			return false;
 
-            self::$encoder->startTag(SYNC_ITEMOPERATIONS_STORE);
-            self::$encoder->content("Mailbox");
-            self::$encoder->endTag();
+		if(!self::$decoder->getElementEndTag()) //find
+			return false;
 
-            self::$encoder->startTag(SYNC_FIND_STATUS);
-            self::$encoder->content(SYNC_FINDSTATUS_SUCCESS);
-            self::$encoder->endTag();
+		ZLog::Write(LOGLEVEL_DEBUG, var_export($cpo->GetDataArray(), true));
 
-            if (isset($rows['range'])) {
-                $searchrange = $rows['range'];
-                unset($rows['range']);
-            }
-            if (isset($rows['searchtotal'])) {
-                $searchtotal = $rows['searchtotal'];
-                unset($rows['searchtotal']);
-            }
 
-            if ($searchtotal > 0) {
-                foreach ($rows as $u) {
-                    // fetch the SyncObject for this result
-                    $message = self::$backend->Fetch(false, $u['longid'], $cpo);
-                    $mfolderid = self::$deviceManager->GetFolderIdForBackendId(bin2hex($message->ParentSourceKey));
 
-                    self::$encoder->startTag(SYNC_FIND_RESULT);
-                    self::$encoder->startTag(SYNC_FOLDERTYPE);
-                    self::$encoder->content($u['class']);
-                    self::$encoder->endTag();
 
-                    self::$encoder->startTag(SYNC_SERVERENTRYID);
-                    self::$encoder->content($mfolderid . ":" . $u['serverid']);
-                    self::$encoder->endTag();
-                    self::$encoder->startTag(SYNC_FOLDERID);
-                    self::$encoder->content($cpo->GetRawFindFolderId());
-                    self::$encoder->endTag();
+		$searchprovider = ZPush::GetSearchProvider();
+		$status = SYNC_SEARCHSTATUS_SUCCESS;
+		$searchtotal = 0;
+		$rows = array();
 
-                    self::$encoder->startTag(SYNC_FIND_PROPERTIES);
-                    $fpmessage = SyncFindProperties::GetObjectFromSyncMail($message);
-                    $fpmessage->Encode(self::$encoder);
+		// TODO support other searches
 
-                    self::$encoder->endTag(); // properties
-                    self::$encoder->endTag(); // result
-                }
-            }
+		switch($searchclass) {
+			case "Email":
+				try {
+					if ($searchprovider->SupportsType(ISearchProvider::SEARCH_MAILBOX)) {
+						$backendFolderId = self::$deviceManager->GetBackendIdForFolderId($cpo->GetSearchFolderid());
+						$cpo->SetFindFolderid($backendFolderId);
+						$rows = $searchprovider->GetMailboxSearchResults($cpo);
+					} else {
+						$rows = array('searchtotal' => 0);
+						$status = SYNC_SEARCHSTATUS_SERVERERROR;
+						ZLog::Write(LOGLEVEL_WARN, sprintf("Searchtype '%s' is not supported.", $searchclass));
+						self::$topCollector->AnnounceInformation(sprintf("Unsupported type '%s''", $searchclass), true);
+					}
+				} catch(StatusException $stex) {
+					$storestatus = $stex->getCode();
+				}
+				break;
 
-            self::$encoder->startTag(SYNC_FIND_RANGE);
-            self::$encoder->content("0-" . $searchtotal);
-            self::$encoder->endTag();
-            if (isset($searchtotal) && $searchtotal > 0) {
-                self::$encoder->startTag(SYNC_FIND_TOTAL);
-                self::$encoder->content($searchtotal); // $searchtotal);
-                self::$encoder->endTag();
-            }
+			case "GAL":
+				//TODO
+//			    $rows = $searchprovider->GetGALSearchResults($searchquery, $searchrange, $searchpicture);
+				break;
+		}
 
-            self::$encoder->endTag(); // SYNC_FIND_RESPONSE
-        }
-        self::$encoder->endTag(); // SYNC_FIND_FIND
+		if (isset($rows['range'])) {
+			$searchrange = $rows['range'];
+			unset($rows['range']);
+		}
+		if (isset($rows['searchtotal'])) {
+			$searchtotal = $rows['searchtotal'];
+			unset($rows['searchtotal']);
+		}
 
-        return true;
-    }
+
+		self::$encoder->startWBXML();
+		self::$encoder->startTag(SYNC_FIND_FIND);
+
+		self::$encoder->startTag(SYNC_FIND_STATUS);
+		self::$encoder->content($status);
+		self::$encoder->endTag();
+
+		self::$encoder->startTag(SYNC_FIND_RESPONSE);
+
+		self::$encoder->startTag(SYNC_ITEMOPERATIONS_STORE);
+		self::$encoder->content("Mailbox");
+		self::$encoder->endTag(); // Store
+
+		self::$encoder->startTag(SYNC_FIND_STATUS);
+		self::$encoder->content($status);
+		self::$encoder->endTag();
+
+
+
+		foreach ($rows as $u) {
+			list($longfolderid, $uid) = Utils::SplitMessageId($u['longid']);
+			$folderid = self::$deviceManager->GetFolderIdForBackendId($u['folderid']);
+			$message = self::$backend->Fetch($folderid, $uid, $cpo);
+
+			/** @var SyncMail $message */
+
+			self::$encoder->startTag(SYNC_FIND_RESULT);
+			self::$encoder->startTag("FolderType"); //Class
+			self::$encoder->content($u['class']);
+			self::$encoder->endTag();
+			self::$encoder->startTag(SYNC_SERVERENTRYID); //ServerId
+			self::$encoder->content($uid);
+			self::$encoder->endTag();
+			self::$encoder->startTag(SYNC_FOLDERID); //CollectionId
+			self::$encoder->content($folderid);
+			self::$encoder->endTag();
+
+			self::$encoder->startTag(SYNC_FIND_PROPERTIES);
+
+			$fpmessage = SyncFindProperties::GetObjectFromSyncMail($message);
+			$fpmessage->Encode(self::$encoder);
+
+			self::$encoder->endTag();//properties
+
+			self::$encoder->endTag();//result
+		}
+
+		self::$encoder->startTag(SYNC_FIND_RANGE);
+		self::$encoder->content($searchrange);
+		self::$encoder->endTag();
+
+		self::$encoder->startTag(SYNC_FIND_TOTAL);
+		self::$encoder->content($searchtotal);
+		self::$encoder->endTag();
+
+		self::$encoder->endTag(); // Response
+
+		self::$encoder->endTag(); //Find
+
+		return true;
+	}
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request replaces my old pull request implementing the Find command. I took the base code and tested it but ran into an issue:

The Find command implementation:

https://github.com/Z-Hub/Z-Push/blob/af25a2169a50d6e05a5916d1e8b2b6cd17011c98/src/lib/request/find.php#L178

Didn't pass the folderId to the backend Fetch() method:

https://github.com/Z-Hub/Z-Push/blob/af25a2169a50d6e05a5916d1e8b2b6cd17011c98/src/lib/default/diffbackend/diffbackend.php#L129

The message can't be found that way. I also pass the server ID and not the long ID as kopano is the only backend that splits the long ID:

https://github.com/Z-Hub/Z-Push/blob/07f60c76cb46d0c63fc18ac387476b304d379087/src/backend/kopano/kopano.php#L750

The BackendDiff class doesn't do this.

Does this close any currently open issues?
------------------------------------------
Not sure. But it might close https://github.com/Z-Hub/Z-Push/issues/141



Any relevant logs, error output, etc?
-------------------------------------
...


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: debian
 - PHP Version: 8.3
 - Backend for: Group-Office
 - and Version: current development branch

**Smartphone (please complete the following information):**
 - Device: iPhone 13
 - OS: iOS 18
 - Mail App Apple mail
