### PR TITLE
Fix for deprectate warning: stripos(): Passing null to parameter #1 (…

### DIFF
--- a/src/lib/request/request.php
+++ b/src/lib/request/request.php
@@ -189,7 +189,7 @@ class Request {
         // process impersonation
         self::$authUser = self::$authUserString; // auth will fail when impersonating & KOE_CAPABILITY_IMPERSONATE is disabled
 
-        if (defined('KOE_CAPABILITY_IMPERSONATE') && KOE_CAPABILITY_IMPERSONATE && stripos(self::$authUserString, self::IMPERSONATE_DELIM) !== false) {
+        if (defined('KOE_CAPABILITY_IMPERSONATE') && KOE_CAPABILITY_IMPERSONATE && isset(self::$authUserString) && stripos(self::$authUserString, self::IMPERSONATE_DELIM) !== false) {
             list(self::$authUser, self::$impersonatedUser) = explode(self::IMPERSONATE_DELIM, self::$authUserString);
         }
 


### PR DESCRIPTION
If you have deprecated warnings on you'll get an error on each request:

Fix for deprectate warning: stripos(): Passing null to parameter #1 ($haystack) of type string is deprecated

Z-Push/src/lib/request/request.php

This PR fixes that.