### PR TITLE
Fix: IMAP Header Array Handling, Multipart Boundary Fallback, and Robust Date Parsing

### DIFF
--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -1318,7 +1318,9 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
             unset($textBody);
             unset($mail_headers);
 
-            $output->datereceived = isset($message->headers["date"]) ? $this->cleanupDate($message->headers["date"]) : null;
+            $output->datereceived = null;
+            if (isset($message->headers["date"]))
+                $output->datereceived = is_array($message->headers["date"]) ? $message->headers["date"][0] : $message->headers["date"];
 
             if ($is_smime) {
                 // #190, KD 2015-06-04 - Add Encrypted (and possibly signed) to the classifications emitted
@@ -1332,10 +1334,15 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
             else {
                 $output->messageclass = "IPM.Note";
             }
-            $output->subject = isset($message->headers["subject"]) ? $message->headers["subject"] : "";
-            $output->read = $stat["flags"];
-            $output->from = isset($message->headers["from"]) ? $message->headers["from"] : null;
+            $output->subject = null;
+            if (isset($message->headers["subject"]))
+                $output->subject = is_array($message->headers["subject"]) ? $message->headers["subject"][0] : $message->headers["subject"];
 
+            $output->read = $stat["flags"];
+
+            $output->from = null;
+            if (isset($message->headers["from"]))
+                $output->from = is_array($message->headers["from"]) ? $message->headers["from"][0] : $message->headers["from"];
             if (isset($message->headers["thread-topic"])) {
                 $output->threadtopic = $message->headers["thread-topic"];
             }

--- a/src/include/mimeDecode.php
+++ b/src/include/mimeDecode.php
@@ -347,9 +347,14 @@ class Mail_mimeDecode
                 case 'multipart/relative': //#20431 - android
                 case 'multipart/mixed':
                 case 'application/vnd.wap.multipart.related':
-                    if(!isset($content_type['other']['boundary'])){
-                        $this->_error = 'No boundary found for ' . $content_type['value'] . ' part';
-                        return false;
+                    if (!isset($content_type['other']['boundary'])) {
+                        if ($this->_include_bodies) {
+                            $encoding = isset($content_transfer_encoding['value']) ? $content_transfer_encoding['value'] : '7bit';
+                            $charset = isset($content_type['other']['charset']) ? $content_type['other']['charset'] : $this->_charset;
+                            $return->body = $this->_decode_bodies ? $this->_decodeBody($body, $encoding, $charset, false) : $body;
+                        }
+                        $this->_error = 'Boundary missing in part ' . $content_type['value'] . ', content treated as plain text.';
+                        break;
                     }
 
                     $default_ctype = (strtolower($content_type['value']) === 'multipart/digest') ? 'message/rfc822' : 'text/plain';

--- a/src/include/z_RFC822.php
+++ b/src/include/z_RFC822.php
@@ -199,6 +199,7 @@ class Mail_RFC822 {
 
         if (isset($address))        $this->address        = $address;
         // z-push addition
+	if (is_array($this->address)) $this->address      = $this->address[0];
         if (strlen(trim((string) $this->address)) == 0) return array();
         if (isset($default_domain)) $this->default_domain = $default_domain;
         if (isset($nest_groups))    $this->nestGroups     = $nest_groups;

--- a/src/lib/utils/timezoneutil.php
+++ b/src/lib/utils/timezoneutil.php
@@ -1319,8 +1319,12 @@ class TimezoneUtil {
             //If there is no timezone set, we use the default timezone
             $tz = timezone_open(date_default_timezone_get());
         }
-        //20110930T090000Z
-        $date = date_create_from_format('Ymd\THis\Z', $value, timezone_open("UTC"));
+        //2025-03-27T130000
+        $date = date_create_from_format('Y-m-d\THis', $value, $tz);
+        if (!$date) {
+            //20110930T090000Z
+            $date = date_create_from_format('Ymd\THis\Z', $value, timezone_open("UTC"));
+        }
         if (!$date) {
             //20110930T090000
             $date = date_create_from_format('Ymd\THis', $value, $tz);
@@ -1331,6 +1335,7 @@ class TimezoneUtil {
         }
         if (!$date) {
             ZLog::Write(LOGLEVEL_ERROR, sprintf("TimezoneUtil::MakeUTCDate(): failed to convert '%s' to date", $value));
+            return false;
         }
         return date_timestamp_get($date);
     }


### PR DESCRIPTION
**Released under the GNU Affero General Public License (AGPL), version 3**
**Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms.**


---

### What does this implement/fix?

This pull request addresses multiple issues related to header handling, multipart messages, and date parsing in the IMAP backend.

---

#### ✅ Fix: Handle header fields as arrays in IMAP backend and address parser

- Adjusted the handling of `"date"`, `"subject"`, and `"from"` headers in `BackendIMAP` to support array values (safely fallback to the first element when necessary).  
- Ensured `Mail_RFC822` address parser uses the first element of the address array to avoid invalid parsing.  
- Prevents fatal errors caused by type mismatches when multi-valued headers are processed.

---

#### ✅ Fix: Handle missing `boundary` in multipart messages

- Previously, `mimeDecode` would fail when a `multipart/*` message lacked a `boundary` parameter.  
- This fix treats such cases as plain text, ensuring content is still parsed and decoded when requested.  
- Prevents silent message loss and improves compatibility with malformed emails.

---

#### ✅ Improve date parsing in `TimezoneUtil::MakeUTCDate`

- Added support for the ISO format `'Y-m-d\THis'` (e.g., `2025-03-27T130000`).  
- Returns `false` explicitly when all parsing attempts fail and logs an error to assist with debugging.

---

### Does this close any currently open issues?

- Closes [#130](https://github.com/Z-Hub/Z-Push/issues/130)

---

### Any relevant logs, error output, etc?

#### **Error 1 – Header as array:**

[FATAL] [xxx@domain.com] Uncaught TypeError: strlen(): Argument #1 ($str) must be of type string, array given
in /usr/local/lib/z-push/lib/core/streamer.php:309

#### **Error 2 – Invalid DateTime parsing:**

[FATAL] [xxx@domain.com] Uncaught TypeError: date_timestamp_get(): Argument #1 ($object) must be of type DateTimeInterface, false given
in /usr/local/lib/z-push/lib/utils/timezoneutil.php:1335


---

### Where has this been tested?

**Sample messages (for reproduction):**  
📎 [bugs.zip](https://github.com/user-attachments/files/20767136/bugs.zip)

**Test Environment:**

- **OS:** Ubuntu 22.04  
- **PHP Version:** 8.2  
- **Backend:** Mail-in-a-Box (v72)

**Client:**

- **Device:** PC  
- **OS:** Windows 10  
- **Mail App:** MS Outlook 2019


