### PR TITLE
Update imap.php to fix S/MIME handling

### DIFF
--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -1226,13 +1226,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
                         break;
                     case SYNC_BODYPREFERENCE_MIME:
                         if ($is_smime) {
-                            if ($is_encrypted) {
-                                // #190, KD 2015-06-04 - If message body is encrypted only send the headers, as data should only be in the attachment
-                                $data = $mail_headers;
-                            }
-                            else {
-                                $data = $mail;
-                            }
+                            $data = $mail;
                         }
                         else {
                             $data = build_mime_message($message);


### PR DESCRIPTION
Undo KD 2015-06-04 to fix broken S/MIME decryption on iOS. Since iOS 12, Mail expects the full message, not just the header. Tested on iOS 26.

Released under the GNU Affero General Public License (AGPL), version 3

What does this implement/fix? Explain your changes.
---------------------------------------------------
S/MIME decryption is broken on modern versions of iOS (see, for example, [https://forum.kopano.io/topic/2619/backendimap-s-mime-decryption-broken-for-ios-12-x-devices-with-z-push](https://forum.kopano.io/topic/2619/backendimap-s-mime-decryption-broken-for-ios-12-x-devices-with-z-push)). This basically undoes an earlier fix, which created this new error.

Does this close any currently open issues?
------------------------------------------
I didn't think that it was worth opening an issue for a relatively straightforward fix.


Any relevant logs, error output, etc?
-------------------------------------
When an S/MIME encrypted message is received on iOS, mail.app displays the error “This message is encrypted. Install a profile containing your encryption identity to decrypt this message”, despite an appropriate profile being installed. This fix removes this error.

Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: Debian
 - PHP Version:8.2
 - Backend for: Stalwart Mail (IMAP)
 - and Version: develop branch

**Smartphone (please complete the following information):**
 - Device: iPhone 15
 - OS: iOS 26
 - Mail App: Apple Mail