### PR TITLE
Stalwart JMAP support for Z-Push.

### DIFF
--- a/src/backend/jmap/config.php
+++ b/src/backend/jmap/config.php
@@ -1,0 +1,39 @@
+<?php
+/***********************************************
+* File      :   config.php
+* Project   :   Z-Push
+* Descr     :   JMAP backend configuration
+*
+* Copyright 2024 - Z-Push Contributors
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License, version 3,
+* as published by the Free Software Foundation.
+*
+* Consult LICENSE file for details
+************************************************/
+
+// JMAP session endpoint URL
+if (!defined('JMAP_SESSION_URL')) {
+    define('JMAP_SESSION_URL', 'https://stalwart.url/jmap/session');
+}
+
+// Whether to verify SSL certificates (disable only for development)
+if (!defined('JMAP_SSL_VERIFY')) {
+    define('JMAP_SSL_VERIFY', true);
+}
+
+// HTTP timeout in seconds for JMAP requests
+if (!defined('JMAP_TIMEOUT')) {
+    define('JMAP_TIMEOUT', 30);
+}
+
+// Maximum number of email IDs to fetch in one Email/get call
+if (!defined('JMAP_MAX_OBJECTS_PER_REQUEST')) {
+    define('JMAP_MAX_OBJECTS_PER_REQUEST', 500);
+}
+
+// How many bytes of body to fetch for the preview/truncation check (0 = unlimited)
+if (!defined('JMAP_MAX_BODY_BYTES')) {
+    define('JMAP_MAX_BODY_BYTES', 0);
+}

--- a/src/backend/jmap/jmap.php
+++ b/src/backend/jmap/jmap.php
@@ -473,7 +473,7 @@ class BackendJmap extends BackendDiff {
                     'hasAttachment', 'textBody', 'htmlBody', 'attachments', 'bodyValues',
                 ],
                 'fetchAllBodyValues' => true,
-                'maxBodyValueBytes'  => JMAP_MAX_BODY_BYTES,
+                ...(JMAP_MAX_BODY_BYTES > 0 ? ['maxBodyValueBytes' => JMAP_MAX_BODY_BYTES] : []),
             ], '0'],
         ]);
 
@@ -553,9 +553,12 @@ class BackendJmap extends BackendDiff {
         $output->subject      = $email['subject']  ?? '';
         $output->from         = $this->formatAddressList($email['from']    ?? []);
         $output->to           = $this->formatAddressList($email['to']      ?? []);
-        $output->cc           = $this->formatAddressList($email['cc']      ?? []);
-        $output->bcc          = $this->formatAddressList($email['bcc']     ?? []);
-        $output->reply_to     = $this->formatAddressList($email['replyTo'] ?? []);
+        $cc      = $this->formatAddressList($email['cc']      ?? []);
+        $bcc     = $this->formatAddressList($email['bcc']     ?? []);
+        $replyTo = $this->formatAddressList($email['replyTo'] ?? []);
+        if ($cc)      $output->cc       = $cc;
+        if ($bcc)     $output->bcc      = $bcc;
+        if ($replyTo) $output->reply_to = $replyTo;
         $output->datereceived = $this->parseJmapDate($email['receivedAt']  ?? '');
         $output->messageclass = 'IPM.Note';
         $output->read         = isset($email['keywords'][self::KW_SEEN]) ? 1 : 0;
@@ -597,13 +600,21 @@ class BackendJmap extends BackendDiff {
 
         if (in_array(SYNC_BODYPREFERENCE_MIME, $bodypreference, true) && !empty($email['blobId'])) {
             try {
-                return [SYNC_BODYPREFERENCE_MIME, $this->client->downloadBlob($email['blobId'], 'message.eml', 'message/rfc822')];
+                $mime = $this->client->downloadBlob($email['blobId'], 'message.eml', 'message/rfc822');
+                if ($mime !== '') {
+                    return [SYNC_BODYPREFERENCE_MIME, $mime];
+                }
+                ZLog::Write(LOGLEVEL_WARN, sprintf('BackendJmap->selectBody(): empty MIME blob for email %s, falling back to HTML/text', $email['id'] ?? '?'));
             } catch (\Throwable $e) {
                 ZLog::Write(LOGLEVEL_WARN, 'BackendJmap->selectBody(): MIME download failed: ' . $e->getMessage());
             }
         }
 
-        $wantHtml = in_array(SYNC_BODYPREFERENCE_HTML, $bodypreference, true) || !$bodypreference;
+        // Prefer HTML if the client wants it, or if no specific preference (also used as
+        // fallback when MIME failed — we try HTML/text regardless of original preference).
+        $wantHtml = !$bodypreference
+            || in_array(SYNC_BODYPREFERENCE_HTML,  $bodypreference, true)
+            || in_array(SYNC_BODYPREFERENCE_MIME,  $bodypreference, true);
         if ($wantHtml && !empty($email['htmlBody'])) {
             $partId = $email['htmlBody'][0]['partId'] ?? null;
             if ($partId && isset($bodyValues[$partId]['value'])) {
@@ -618,6 +629,26 @@ class BackendJmap extends BackendDiff {
             }
         }
 
+        // bodyValues was empty or partIds didn't match — last resort: download raw MIME
+        if (!empty($email['blobId'])) {
+            try {
+                $mime = $this->client->downloadBlob($email['blobId'], 'message.eml', 'message/rfc822');
+                if ($mime !== '') {
+                    ZLog::Write(LOGLEVEL_DEBUG, sprintf('BackendJmap->selectBody(): used MIME fallback for email %s', $email['id'] ?? '?'));
+                    return [SYNC_BODYPREFERENCE_MIME, $mime];
+                }
+            } catch (\Throwable $e) {
+                ZLog::Write(LOGLEVEL_WARN, 'BackendJmap->selectBody(): MIME fallback failed: ' . $e->getMessage());
+            }
+        }
+
+        ZLog::Write(LOGLEVEL_WARN, sprintf(
+            'BackendJmap->selectBody(): no usable body for email %s (htmlBody=%d textBody=%d bodyValues=%d)',
+            $email['id'] ?? '?',
+            count($email['htmlBody'] ?? []),
+            count($email['textBody'] ?? []),
+            count($bodyValues)
+        ));
         return [SYNC_BODYPREFERENCE_PLAIN, ''];
     }
 
@@ -1064,6 +1095,7 @@ class BackendJmap extends BackendDiff {
         foreach ($addresses as $addr) {
             $email = $addr['email'] ?? '';
             $name  = $addr['name']  ?? '';
+            if (!$email && !$name) continue;
             $parts[] = $name ? '"' . addslashes($name) . '" <' . $email . '>' : $email;
         }
         return implode(', ', $parts);

--- a/src/backend/jmap/jmap.php
+++ b/src/backend/jmap/jmap.php
@@ -1,0 +1,1097 @@
+<?php
+/***********************************************
+* File      :   jmap.php
+* Project   :   Z-Push
+* Descr     :   JMAP backend for Z-Push. Implements the BackendDiff
+*               pattern so no custom importer/exporter is needed.
+*               Supports mail, contacts (JSContact) and calendars
+*               (JSCalendar) via Stalwart or any RFC-compliant JMAP
+*               server.
+*
+* Copyright 2024 - Z-Push Contributors
+* AGPL-3.0 - see LICENSE
+************************************************/
+
+require_once 'backend/jmap/config.php';
+require_once 'backend/jmap/jmap_client.php';
+require_once 'backend/jmap/jmap_contacts.php';
+require_once 'backend/jmap/jmap_calendar.php';
+
+class BackendJmap extends BackendDiff {
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    const KW_SEEN      = '$seen';
+    const KW_FLAGGED   = '$flagged';
+    const KW_ANSWERED  = '$answered';
+    const KW_FORWARDED = '$forwarded';
+    const KW_DRAFT     = '$draft';
+
+    // Folder-ID prefixes used to distinguish resource types.
+    // Mail folders keep their raw JMAP IDs for backwards compatibility.
+    const PFX_CONTACTS = 'ab_';
+    const PFX_CALENDAR = 'cal_';
+
+    private const ROLE_TO_AS_TYPE = [
+        'inbox'   => SYNC_FOLDER_TYPE_INBOX,
+        'drafts'  => SYNC_FOLDER_TYPE_DRAFTS,
+        'trash'   => SYNC_FOLDER_TYPE_WASTEBASKET,
+        'sent'    => SYNC_FOLDER_TYPE_SENTMAIL,
+        'junk'    => SYNC_FOLDER_TYPE_USER_MAIL,
+        'spam'    => SYNC_FOLDER_TYPE_USER_MAIL,
+        'archive' => SYNC_FOLDER_TYPE_USER_MAIL,
+    ];
+
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    private ?JmapClient $client     = null;
+    private string      $accountId  = '';
+    private string      $username   = '';
+    private string      $identityId   = '';
+    private string      $identityName = '';
+
+    private array $sinkStates     = [];
+    private bool  $sinkInitialized = false;
+
+    // -------------------------------------------------------------------------
+    // IBackend: Auth
+    // -------------------------------------------------------------------------
+
+    public function Logon($username, $domain, $password): bool {
+        if (!function_exists('curl_init')) {
+            throw new FatalException('BackendJmap->Logon(): php-curl is required', 0, null, LOGLEVEL_FATAL);
+        }
+
+        $this->username = $username;
+        $this->client   = new JmapClient(JMAP_SESSION_URL, $username, $password);
+
+        try {
+            // One HTTP request — fetches session and verifies credentials.
+            // identityId is lazy-loaded only when SendMail() needs it.
+            $this->accountId = $this->client->getAccountId();
+            ZLog::Write(LOGLEVEL_DEBUG, sprintf(
+                'BackendJmap->Logon(): user="%s" accountId="%s"',
+                $username, $this->accountId
+            ));
+            return true;
+        } catch (AuthenticationRequiredException $e) {
+            ZLog::Write(LOGLEVEL_WARN, sprintf('BackendJmap->Logon(): auth failed for "%s"', $username));
+            return false;
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->Logon(): %s', $e->getMessage()));
+            return false;
+        }
+    }
+
+    public function Logoff(): bool {
+        $this->SaveStorages();
+        $this->client    = null;
+        $this->accountId = '';
+        return true;
+    }
+
+    public function GetSupportedASVersion(): string {
+        return ZPush::ASV_14;
+    }
+
+    // -------------------------------------------------------------------------
+    // IBackend: Mail sending
+    // -------------------------------------------------------------------------
+
+    public function SendMail($sm): bool {
+        ZLog::Write(LOGLEVEL_DEBUG, 'BackendJmap->SendMail()');
+
+        if (empty($sm->mime)) {
+            throw new StatusException('BackendJmap->SendMail(): empty MIME', SYNC_COMMONSTATUS_MAILSUBMISSIONFAILED);
+        }
+
+        try {
+            $mime = $sm->mime;
+            $identityName = $this->getIdentityName();
+            if ($identityName !== '') {
+                $mime = $this->rewriteFromHeader($mime, $identityName);
+            }
+
+            $blobId        = $this->client->uploadBlob($mime, 'message/rfc822');
+            $sentMailboxId = $this->getSentMailboxId();
+            $saveCopy      = !isset($sm->saveinsentitems) || $sm->saveinsentitems;
+
+            $mailboxIds = $sentMailboxId ? [$sentMailboxId => true] : [];
+
+            $importResponses = $this->client->call([
+                ['Email/import', [
+                    'accountId' => $this->accountId,
+                    'emails'    => ['i1' => [
+                        'blobId'     => $blobId,
+                        'mailboxIds' => $mailboxIds ?: [$this->accountId => true],
+                        'keywords'   => [self::KW_SEEN => true],
+                        'receivedAt' => gmdate('Y-m-d\TH:i:s\Z'),
+                    ]],
+                ], 'im'],
+            ], [JmapClient::CAP_CORE, JmapClient::CAP_MAIL]);
+
+            $importedId = $importResponses[0][1]['created']['i1']['id'] ?? null;
+            if ($importedId === null) {
+                $err = $importResponses[0][1]['notCreated']['i1'] ?? 'unknown';
+                throw new StatusException(
+                    sprintf('BackendJmap->SendMail(): import failed: %s', json_encode($err)),
+                    SYNC_COMMONSTATUS_MAILSUBMISSIONFAILED
+                );
+            }
+
+            $subResponses = $this->client->call([
+                ['EmailSubmission/set', [
+                    'accountId' => $this->accountId,
+                    'create'    => ['s1' => [
+                        'emailId'    => $importedId,
+                        'identityId' => $this->getIdentityId(),
+                        'envelope'   => null,
+                    ]],
+                ], 'sub'],
+            ], [JmapClient::CAP_CORE, JmapClient::CAP_MAIL, JmapClient::CAP_SUBMIT]);
+
+            $notCreated = $subResponses[0][1]['notCreated'] ?? [];
+            if (!empty($notCreated)) {
+                $err = reset($notCreated);
+                throw new StatusException(
+                    sprintf('BackendJmap->SendMail(): submission failed: %s', json_encode($err)),
+                    SYNC_COMMONSTATUS_MAILSUBMISSIONFAILED
+                );
+            }
+
+            if (isset($sm->source->itemid)) {
+                $kw = [];
+                if (!empty($sm->replyflag))   $kw[self::KW_ANSWERED]  = true;
+                if (!empty($sm->forwardflag)) $kw[self::KW_FORWARDED] = true;
+                if ($kw) $this->setKeywords($sm->source->itemid, $kw);
+            }
+
+            return true;
+        } catch (StatusException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            throw new StatusException(
+                sprintf('BackendJmap->SendMail(): %s', $e->getMessage()),
+                SYNC_COMMONSTATUS_MAILSUBMISSIONFAILED
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // IBackend: Attachment download
+    // -------------------------------------------------------------------------
+
+    public function GetAttachmentData($attname): SyncItemOperationsAttachment {
+        $parts  = explode('||', $attname, 3);
+        $blobId = $parts[1] ?? '';
+        $name   = $parts[2] ?? 'attachment';
+
+        if (!$blobId) {
+            throw new StatusException(
+                sprintf('BackendJmap->GetAttachmentData(): bad ref "%s"', $attname),
+                SYNC_ITEMOPERATIONSSTATUS_INVALIDATT
+            );
+        }
+
+        try {
+            $data = $this->client->downloadBlob($blobId, $name);
+        } catch (\Throwable $e) {
+            throw new StatusException(
+                sprintf('BackendJmap->GetAttachmentData(): %s', $e->getMessage()),
+                SYNC_ITEMOPERATIONSSTATUS_INVALIDATT
+            );
+        }
+
+        $attachment              = new SyncItemOperationsAttachment();
+        $attachment->data        = StringStreamWrapper::Open($data);
+        $attachment->contenttype = $this->extToMime(strtolower(pathinfo($name, PATHINFO_EXTENSION)));
+        return $attachment;
+    }
+
+    // -------------------------------------------------------------------------
+    // IBackend: Waste basket & sink
+    // -------------------------------------------------------------------------
+
+    public function GetWasteBasket(): string|false {
+        try {
+            return $this->getMailboxIdByRole('trash') ?: false;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    public function HasChangesSink(): bool { return true; }
+
+    public function ChangesSinkInitialize($folderid): bool {
+        try {
+            $this->sinkStates[$folderid] = $this->getFolderQueryState($folderid);
+            $this->sinkInitialized = true;
+            return true;
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->ChangesSinkInitialize(): %s', $e->getMessage()));
+            return false;
+        }
+    }
+
+    public function ChangesSink($timeout = 30): array {
+        if (!$this->sinkInitialized || !$this->sinkStates) return [];
+
+        $start   = time();
+        $changed = [];
+
+        while (time() - $start < $timeout) {
+            try {
+                foreach ($this->sinkStates as $folderid => $saved) {
+                    $current = $this->getFolderQueryState($folderid);
+                    if ($current !== $saved) {
+                        $this->sinkStates[$folderid] = $current;
+                        $changed[] = $folderid;
+                    }
+                }
+            } catch (\Throwable $e) {
+                ZLog::Write(LOGLEVEL_WARN, sprintf('BackendJmap->ChangesSink(): %s', $e->getMessage()));
+            }
+
+            if ($changed) return $changed;
+            sleep(5);
+        }
+        return [];
+    }
+
+    // -------------------------------------------------------------------------
+    // BackendDiff: Folder list / hierarchy
+    // -------------------------------------------------------------------------
+
+    public function GetFolderList(): array {
+        try {
+            $out = [];
+
+            // Mail mailboxes
+            foreach ($this->getAllMailboxes() as $mb) {
+                $out[] = ['id' => $mb['id'], 'parent' => $mb['parentId'] ?? false, 'mod' => $mb['id']];
+            }
+
+            // Address books — prefixed with PFX_CONTACTS
+            foreach ($this->getAllAddressBooks() as $ab) {
+                $out[] = ['id' => self::PFX_CONTACTS . $ab['id'], 'parent' => false, 'mod' => $ab['id']];
+            }
+
+            // Calendars — prefixed with PFX_CALENDAR
+            foreach ($this->getAllCalendars() as $cal) {
+                $out[] = ['id' => self::PFX_CALENDAR . $cal['id'], 'parent' => false, 'mod' => $cal['id']];
+            }
+
+            return $out;
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->GetFolderList(): %s', $e->getMessage()));
+            return [];
+        }
+    }
+
+    public function GetFolder($id): SyncFolder|false {
+        try {
+            return match($this->folderType($id)) {
+                'contacts' => $this->getAddressBookAsFolder($id),
+                'calendar' => $this->getCalendarAsFolder($id),
+                default    => $this->getMailboxAsFolder($id),
+            };
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->GetFolder("%s"): %s', $id, $e->getMessage()));
+            return false;
+        }
+    }
+
+    public function StatFolder($id): array|false {
+        try {
+            $jid = $this->jmapId($id);
+            return ['id' => $id, 'parent' => false, 'mod' => $jid];
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    public function ChangeFolder($folderid, $oldid, $displayname, $type): string|false {
+        try {
+            if (in_array($type, [SYNC_FOLDER_TYPE_CONTACT, SYNC_FOLDER_TYPE_USER_CONTACT], true)) {
+                return $this->changeAddressBook($oldid, $displayname);
+            }
+            if (in_array($type, [SYNC_FOLDER_TYPE_APPOINTMENT, SYNC_FOLDER_TYPE_USER_APPOINTMENT], true)) {
+                return $this->changeCalendar($oldid, $displayname);
+            }
+            return $this->changeMailbox($folderid, $oldid, $displayname);
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->ChangeFolder(): %s', $e->getMessage()));
+            return false;
+        }
+    }
+
+    public function DeleteFolder($id, $parentid): bool {
+        try {
+            return match($this->folderType($id)) {
+                'contacts' => $this->deleteAddressBook($id),
+                'calendar' => $this->deleteCalendar($id),
+                default    => $this->deleteMailbox($id),
+            };
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->DeleteFolder("%s"): %s', $id, $e->getMessage()));
+            return false;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // BackendDiff: Message list & individual messages
+    // -------------------------------------------------------------------------
+
+    public function GetMessageList($folderid, $cutoffdate): array {
+        try {
+            return match($this->folderType($folderid)) {
+                'contacts' => $this->listContacts($this->jmapId($folderid)),
+                'calendar' => $this->listCalendarEvents($this->jmapId($folderid), $cutoffdate),
+                default    => $this->listEmails($folderid, $cutoffdate),
+            };
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->GetMessageList("%s"): %s', $folderid, $e->getMessage()));
+            return [];
+        }
+    }
+
+    public function GetMessage($folderid, $id, $contentparameters): SyncObject|false {
+        try {
+            return match($this->folderType($folderid)) {
+                'contacts' => $this->getContact($id),
+                'calendar' => $this->getCalendarEvent($id),
+                default    => $this->getEmail($folderid, $id, $contentparameters),
+            };
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->GetMessage("%s","%s"): %s', $folderid, $id, $e->getMessage()));
+            return false;
+        }
+    }
+
+    public function StatMessage($folderid, $id): array|false {
+        try {
+            return match($this->folderType($folderid)) {
+                'contacts' => $this->statContact($id),
+                'calendar' => $this->statCalendarEvent($id),
+                default    => $this->statEmail($folderid, $id),
+            };
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->StatMessage("%s","%s"): %s', $folderid, $id, $e->getMessage()));
+            return false;
+        }
+    }
+
+    public function ChangeMessage($folderid, $id, $message, $contentParameters): string|false {
+        try {
+            return match($this->folderType($folderid)) {
+                'contacts' => $this->saveContact($this->jmapId($folderid), $id, $message),
+                'calendar' => $this->saveCalendarEvent($this->jmapId($folderid), $id, $message),
+                default    => $this->saveDraft($folderid, $id, $message, $contentParameters),
+            };
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->ChangeMessage("%s","%s"): %s', $folderid, $id, $e->getMessage()));
+            return false;
+        }
+    }
+
+    public function SetReadFlag($folderid, $id, $flags, $contentParameters): bool {
+        if ($this->folderType($folderid) !== 'mail') return true; // no-op for contacts/calendar
+        try {
+            return $this->setKeywords($id, [self::KW_SEEN => ($flags != 0)]);
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->SetReadFlag(): %s', $e->getMessage()));
+            return false;
+        }
+    }
+
+    public function DeleteMessage($folderid, $id, $contentParameters): bool {
+        try {
+            return match($this->folderType($folderid)) {
+                'contacts' => $this->destroyContact($id),
+                'calendar' => $this->destroyCalendarEvent($id),
+                default    => $this->deleteEmail($folderid, $id, $contentParameters),
+            };
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->DeleteMessage(): %s', $e->getMessage()));
+            return false;
+        }
+    }
+
+    public function MoveMessage($folderid, $id, $newfolderid, $contentParameters): string|false {
+        try {
+            return match($this->folderType($folderid)) {
+                'contacts' => $this->moveContact($id, $this->jmapId($folderid), $this->jmapId($newfolderid)),
+                'calendar' => $this->moveCalendarEvent($id, $this->jmapId($folderid), $this->jmapId($newfolderid)),
+                default    => $this->moveEmail($folderid, $id, $newfolderid),
+            };
+        } catch (\Throwable $e) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf('BackendJmap->MoveMessage(): %s', $e->getMessage()));
+            return false;
+        }
+    }
+
+    // =========================================================================
+    // MAIL helpers
+    // =========================================================================
+
+    private function listEmails(string $folderid, int $cutoffdate): array {
+        $filter = ['inMailbox' => $folderid];
+        if ($cutoffdate > 0) $filter['after'] = gmdate('Y-m-d\TH:i:s\Z', $cutoffdate);
+
+        $r = $this->client->call([
+            ['Email/query', [
+                'accountId' => $this->accountId,
+                'filter'    => $filter,
+                'sort'      => [['property' => 'receivedAt', 'isAscending' => false]],
+                'limit'     => JMAP_MAX_OBJECTS_PER_REQUEST,
+            ], 'q'],
+            ['Email/get', [
+                'accountId'  => $this->accountId,
+                '#ids'       => ['resultOf' => 'q', 'name' => 'Email/query', 'path' => '/ids'],
+                'properties' => ['id', 'keywords'],
+            ], 'g'],
+        ]);
+
+        return array_map(
+            fn($e) => $this->emailToStat($e),
+            $r[1][1]['list'] ?? []
+        );
+    }
+
+    private function getEmail(string $folderid, string $id, $contentparameters): SyncMail|false {
+        $r = $this->client->call([
+            ['Email/get', [
+                'accountId'          => $this->accountId,
+                'ids'                => [$id],
+                'properties'         => [
+                    'id', 'blobId', 'mailboxIds', 'keywords', 'size',
+                    'receivedAt', 'subject', 'from', 'to', 'cc', 'bcc', 'replyTo',
+                    'hasAttachment', 'textBody', 'htmlBody', 'attachments', 'bodyValues',
+                ],
+                'fetchAllBodyValues' => true,
+                'maxBodyValueBytes'  => JMAP_MAX_BODY_BYTES,
+            ], '0'],
+        ]);
+
+        $email = $r[0][1]['list'][0] ?? null;
+        return $email ? $this->buildSyncMail($email, $contentparameters) : false;
+    }
+
+    private function statEmail(string $folderid, string $id): array|false {
+        $r = $this->client->call([
+            ['Email/get', ['accountId' => $this->accountId, 'ids' => [$id], 'properties' => ['id', 'keywords']], '0'],
+        ]);
+        $email = $r[0][1]['list'][0] ?? null;
+        return $email ? $this->emailToStat($email) : false;
+    }
+
+    private function saveDraft(string $folderid, ?string $id, $message, $contentParameters): string|false {
+        if (empty($message->mime)) return false;
+
+        $blobId = $this->client->uploadBlob($message->mime, 'message/rfc822');
+        $folder = $this->GetFolder($folderid);
+        $kw     = ($folder && $folder->type === SYNC_FOLDER_TYPE_DRAFTS) ? [self::KW_DRAFT => true] : [];
+
+        $r = $this->client->call([
+            ['Email/import', [
+                'accountId' => $this->accountId,
+                'emails'    => ['n1' => [
+                    'blobId'     => $blobId,
+                    'mailboxIds' => [$folderid => true],
+                    'keywords'   => $kw,
+                    'receivedAt' => gmdate('Y-m-d\TH:i:s\Z'),
+                ]],
+            ], '0'],
+        ]);
+
+        $created = $r[0][1]['created']['n1'] ?? null;
+        if (!$created) return false;
+
+        if ($id) $this->deleteEmail($folderid, $id, $contentParameters);
+        return $created['id'];
+    }
+
+    private function deleteEmail(string $folderid, string $id, $contentParameters): bool {
+        $trashId = $this->GetWasteBasket();
+        if ($trashId && $folderid !== $trashId) {
+            return $this->moveEmail($folderid, $id, $trashId) !== false;
+        }
+        $r = $this->client->call([
+            ['Email/set', ['accountId' => $this->accountId, 'destroy' => [$id]], '0'],
+        ]);
+        return in_array($id, $r[0][1]['destroyed'] ?? [], true);
+    }
+
+    private function moveEmail(string $folderid, string $id, string $newfolderid): string|false {
+        $r = $this->client->call([
+            ['Email/set', [
+                'accountId' => $this->accountId,
+                'update'    => [$id => [
+                    "mailboxIds/$folderid"    => null,
+                    "mailboxIds/$newfolderid" => true,
+                ]],
+            ], '0'],
+        ]);
+        return isset($r[0][1]['updated'][$id]) ? $id : false;
+    }
+
+    private function emailToStat(array $email): array {
+        $kw = $email['keywords'] ?? [];
+        return [
+            'id'    => $email['id'],
+            'flags' => isset($kw[self::KW_SEEN]) ? 1 : 0,
+            'mod'   => $this->keywordsHash($kw),
+        ];
+    }
+
+    private function buildSyncMail(array $email, $contentparameters): SyncMail {
+        $output = new SyncMail();
+        $output->subject      = $email['subject']  ?? '';
+        $output->from         = $this->formatAddressList($email['from']    ?? []);
+        $output->to           = $this->formatAddressList($email['to']      ?? []);
+        $output->cc           = $this->formatAddressList($email['cc']      ?? []);
+        $output->bcc          = $this->formatAddressList($email['bcc']     ?? []);
+        $output->reply_to     = $this->formatAddressList($email['replyTo'] ?? []);
+        $output->datereceived = $this->parseJmapDate($email['receivedAt']  ?? '');
+        $output->messageclass = 'IPM.Note';
+        $output->read         = isset($email['keywords'][self::KW_SEEN]) ? 1 : 0;
+
+        $bodypreference = $contentparameters->GetBodyPreference() ?: [];
+        [$bodyType, $bodyData] = $this->selectBody($email, $bodypreference);
+        $truncsize = Utils::GetTruncSize($contentparameters->GetTruncation());
+
+        $output->asbody = new SyncBaseBody();
+        $output->asbody->type = $bodyType;
+        if ($truncsize !== -1 && strlen($bodyData) > $truncsize) {
+            $bodyData = substr($bodyData, 0, $truncsize);
+            $output->asbody->truncated = 1;
+        } else {
+            $output->asbody->truncated = 0;
+        }
+        $output->asbody->estimatedDataSize = strlen($bodyData);
+        $output->asbody->data              = StringStreamWrapper::Open($bodyData);
+
+        foreach ($email['attachments'] ?? [] as $att) {
+            $blobId   = $att['blobId'] ?? '';
+            $filename = $att['name']   ?? ('attachment-' . substr($blobId, 0, 8));
+            $inline   = strtolower($att['disposition'] ?? '') === 'inline';
+            $sa = new SyncBaseAttachment();
+            $sa->displayname       = $filename;
+            $sa->filereference     = $email['id'] . '||' . $blobId . '||' . $filename;
+            $sa->method            = 1;
+            $sa->estimatedDataSize = $att['size'] ?? 0;
+            $sa->isinline          = $inline ? 1 : 0;
+            if (!empty($att['cid'])) $sa->contentid = $att['cid'];
+            $output->asattachments[] = $sa;
+        }
+
+        return $output;
+    }
+
+    private function selectBody(array $email, array $bodypreference): array {
+        $bodyValues = $email['bodyValues'] ?? [];
+
+        if (in_array(SYNC_BODYPREFERENCE_MIME, $bodypreference, true) && !empty($email['blobId'])) {
+            try {
+                return [SYNC_BODYPREFERENCE_MIME, $this->client->downloadBlob($email['blobId'], 'message.eml', 'message/rfc822')];
+            } catch (\Throwable $e) {
+                ZLog::Write(LOGLEVEL_WARN, 'BackendJmap->selectBody(): MIME download failed: ' . $e->getMessage());
+            }
+        }
+
+        $wantHtml = in_array(SYNC_BODYPREFERENCE_HTML, $bodypreference, true) || !$bodypreference;
+        if ($wantHtml && !empty($email['htmlBody'])) {
+            $partId = $email['htmlBody'][0]['partId'] ?? null;
+            if ($partId && isset($bodyValues[$partId]['value'])) {
+                return [SYNC_BODYPREFERENCE_HTML, $bodyValues[$partId]['value']];
+            }
+        }
+
+        if (!empty($email['textBody'])) {
+            $partId = $email['textBody'][0]['partId'] ?? null;
+            if ($partId && isset($bodyValues[$partId]['value'])) {
+                return [SYNC_BODYPREFERENCE_PLAIN, $bodyValues[$partId]['value']];
+            }
+        }
+
+        return [SYNC_BODYPREFERENCE_PLAIN, ''];
+    }
+
+    // =========================================================================
+    // CONTACTS helpers
+    // =========================================================================
+
+    private function listContacts(string $abId): array {
+        $r = $this->client->call([
+            ['ContactCard/query', [
+                'accountId' => $this->accountId,
+                'filter'    => ['inAddressBook' => $abId],
+                'limit'     => JMAP_MAX_OBJECTS_PER_REQUEST,
+            ], 'q'],
+            ['ContactCard/get', [
+                'accountId'  => $this->accountId,
+                '#ids'       => ['resultOf' => 'q', 'name' => 'ContactCard/query', 'path' => '/ids'],
+                'properties' => ['id', 'name', 'emails', 'phones', 'updated'],
+            ], 'g'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+
+        return array_map(fn($c) => [
+            'id'    => $c['id'],
+            'flags' => 0,
+            'mod'   => JmapContactConverter::cardModHash($c),
+        ], $r[1][1]['list'] ?? []);
+    }
+
+    private function getContact(string $id): SyncContact|false {
+        $r = $this->client->call([
+            ['ContactCard/get', [
+                'accountId'  => $this->accountId,
+                'ids'        => [$id],
+                'properties' => null,
+            ], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+
+        $card = $r[0][1]['list'][0] ?? null;
+        return $card ? JmapContactConverter::cardToSyncContact($card) : false;
+    }
+
+    private function statContact(string $id): array|false {
+        $r = $this->client->call([
+            ['ContactCard/get', [
+                'accountId'  => $this->accountId,
+                'ids'        => [$id],
+                'properties' => ['id', 'name', 'emails', 'phones', 'updated'],
+            ], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+
+        $card = $r[0][1]['list'][0] ?? null;
+        if (!$card) return false;
+        return ['id' => $card['id'], 'flags' => 0, 'mod' => JmapContactConverter::cardModHash($card)];
+    }
+
+    private function saveContact(string $abId, ?string $id, SyncContact $contact): string|false {
+        $card = JmapContactConverter::syncContactToCard($contact, $abId);
+
+        if ($id) {
+            $r = $this->client->call([
+                ['ContactCard/set', [
+                    'accountId' => $this->accountId,
+                    'update'    => [$id => $card],
+                ], '0'],
+            ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+            return isset($r[0][1]['updated'][$id]) ? $id : false;
+        }
+
+        $r = $this->client->call([
+            ['ContactCard/set', [
+                'accountId' => $this->accountId,
+                'create'    => ['c1' => $card],
+            ], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+
+        return $r[0][1]['created']['c1']['id'] ?? false;
+    }
+
+    private function destroyContact(string $id): bool {
+        $r = $this->client->call([
+            ['ContactCard/set', ['accountId' => $this->accountId, 'destroy' => [$id]], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+        return in_array($id, $r[0][1]['destroyed'] ?? [], true);
+    }
+
+    private function moveContact(string $id, string $fromAbId, string $toAbId): string|false {
+        $r = $this->client->call([
+            ['ContactCard/set', [
+                'accountId' => $this->accountId,
+                'update'    => [$id => [
+                    "addressBookIds/$fromAbId" => null,
+                    "addressBookIds/$toAbId"   => true,
+                ]],
+            ], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+        return isset($r[0][1]['updated'][$id]) ? $id : false;
+    }
+
+    // =========================================================================
+    // CALENDAR helpers
+    // =========================================================================
+
+    private function listCalendarEvents(string $calId, int $cutoffdate): array {
+        $filter = ['inCalendar' => $calId];
+        if ($cutoffdate > 0) {
+            $filter['after'] = gmdate('Y-m-d\TH:i:s\Z', $cutoffdate);
+        }
+
+        $r = $this->client->call([
+            ['CalendarEvent/query', [
+                'accountId' => $this->accountId,
+                'filter'    => $filter,
+                'limit'     => JMAP_MAX_OBJECTS_PER_REQUEST,
+            ], 'q'],
+            ['CalendarEvent/get', [
+                'accountId'  => $this->accountId,
+                '#ids'       => ['resultOf' => 'q', 'name' => 'CalendarEvent/query', 'path' => '/ids'],
+                'properties' => ['id', 'title', 'start', 'duration', 'updated'],
+            ], 'g'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+
+        return array_map(fn($e) => [
+            'id'    => $e['id'],
+            'flags' => 0,
+            'mod'   => JmapCalendarConverter::eventModHash($e),
+        ], $r[1][1]['list'] ?? []);
+    }
+
+    private function getCalendarEvent(string $id): SyncAppointment|false {
+        $r = $this->client->call([
+            ['CalendarEvent/get', [
+                'accountId'  => $this->accountId,
+                'ids'        => [$id],
+                'properties' => null,
+            ], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+
+        $event = $r[0][1]['list'][0] ?? null;
+        return $event ? JmapCalendarConverter::eventToSyncAppointment($event) : false;
+    }
+
+    private function statCalendarEvent(string $id): array|false {
+        $r = $this->client->call([
+            ['CalendarEvent/get', [
+                'accountId'  => $this->accountId,
+                'ids'        => [$id],
+                'properties' => ['id', 'title', 'start', 'duration', 'updated'],
+            ], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+
+        $event = $r[0][1]['list'][0] ?? null;
+        if (!$event) return false;
+        return ['id' => $event['id'], 'flags' => 0, 'mod' => JmapCalendarConverter::eventModHash($event)];
+    }
+
+    private function saveCalendarEvent(string $calId, ?string $id, SyncAppointment $appt): string|false {
+        $event = JmapCalendarConverter::syncAppointmentToEvent($appt, $calId);
+
+        if ($id) {
+            $r = $this->client->call([
+                ['CalendarEvent/set', [
+                    'accountId' => $this->accountId,
+                    'update'    => [$id => $event],
+                ], '0'],
+            ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+            return isset($r[0][1]['updated'][$id]) ? $id : false;
+        }
+
+        $r = $this->client->call([
+            ['CalendarEvent/set', [
+                'accountId' => $this->accountId,
+                'create'    => ['ev1' => $event],
+            ], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+
+        return $r[0][1]['created']['ev1']['id'] ?? false;
+    }
+
+    private function destroyCalendarEvent(string $id): bool {
+        $r = $this->client->call([
+            ['CalendarEvent/set', ['accountId' => $this->accountId, 'destroy' => [$id]], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+        return in_array($id, $r[0][1]['destroyed'] ?? [], true);
+    }
+
+    private function moveCalendarEvent(string $id, string $fromCalId, string $toCalId): string|false {
+        $r = $this->client->call([
+            ['CalendarEvent/set', [
+                'accountId' => $this->accountId,
+                'update'    => [$id => [
+                    "calendarIds/$fromCalId" => null,
+                    "calendarIds/$toCalId"   => true,
+                ]],
+            ], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+        return isset($r[0][1]['updated'][$id]) ? $id : false;
+    }
+
+    // =========================================================================
+    // Folder CRUD helpers
+    // =========================================================================
+
+    private function getMailboxAsFolder(string $id): SyncFolder|false {
+        $r = $this->client->call([
+            ['Mailbox/get', ['accountId' => $this->accountId, 'ids' => [$id]], '0'],
+        ]);
+        $mb = $r[0][1]['list'][0] ?? null;
+        if (!$mb) return false;
+        $f = new SyncFolder();
+        $f->serverid    = $mb['id'];
+        $f->parentid    = $mb['parentId'] ?? '0';
+        $f->displayname = $mb['name'];
+        $f->type        = self::ROLE_TO_AS_TYPE[$mb['role'] ?? ''] ?? SYNC_FOLDER_TYPE_USER_MAIL;
+        return $f;
+    }
+
+    private function getAddressBookAsFolder(string $id): SyncFolder|false {
+        $jid = $this->jmapId($id);
+        $r   = $this->client->call([
+            ['AddressBook/get', ['accountId' => $this->accountId, 'ids' => [$jid]], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+        $ab = $r[0][1]['list'][0] ?? null;
+        if (!$ab) return false;
+        $f = new SyncFolder();
+        $f->serverid    = $id;
+        $f->parentid    = '0';
+        $f->displayname = $ab['name'];
+        $f->type        = !empty($ab['isDefault']) ? SYNC_FOLDER_TYPE_CONTACT : SYNC_FOLDER_TYPE_USER_CONTACT;
+        return $f;
+    }
+
+    private function getCalendarAsFolder(string $id): SyncFolder|false {
+        $jid = $this->jmapId($id);
+        $r   = $this->client->call([
+            ['Calendar/get', ['accountId' => $this->accountId, 'ids' => [$jid]], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+        $cal = $r[0][1]['list'][0] ?? null;
+        if (!$cal) return false;
+        $f = new SyncFolder();
+        $f->serverid    = $id;
+        $f->parentid    = '0';
+        $f->displayname = $cal['name'];
+        $f->type        = !empty($cal['isDefault']) ? SYNC_FOLDER_TYPE_APPOINTMENT : SYNC_FOLDER_TYPE_USER_APPOINTMENT;
+        return $f;
+    }
+
+    private function changeMailbox(string $folderid, ?string $oldid, string $name): string|false {
+        if ($oldid) {
+            $r = $this->client->call([
+                ['Mailbox/set', ['accountId' => $this->accountId, 'update' => [$oldid => ['name' => $name]]], '0'],
+            ]);
+            return isset($r[0][1]['updated'][$oldid]) ? $oldid : false;
+        }
+        $create = ['name' => $name];
+        if ($folderid) $create['parentId'] = $folderid;
+        $r = $this->client->call([
+            ['Mailbox/set', ['accountId' => $this->accountId, 'create' => ['n1' => $create]], '0'],
+        ]);
+        return $r[0][1]['created']['n1']['id'] ?? false;
+    }
+
+    private function changeAddressBook(?string $oldid, string $name): string|false {
+        if ($oldid) {
+            $jid = $this->jmapId($oldid);
+            $r   = $this->client->call([
+                ['AddressBook/set', ['accountId' => $this->accountId, 'update' => [$jid => ['name' => $name]]], '0'],
+            ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+            return isset($r[0][1]['updated'][$jid]) ? $oldid : false;
+        }
+        $r = $this->client->call([
+            ['AddressBook/set', ['accountId' => $this->accountId, 'create' => ['ab1' => ['name' => $name]]], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+        $newId = $r[0][1]['created']['ab1']['id'] ?? null;
+        return $newId ? self::PFX_CONTACTS . $newId : false;
+    }
+
+    private function changeCalendar(?string $oldid, string $name): string|false {
+        if ($oldid) {
+            $jid = $this->jmapId($oldid);
+            $r   = $this->client->call([
+                ['Calendar/set', ['accountId' => $this->accountId, 'update' => [$jid => ['name' => $name]]], '0'],
+            ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+            return isset($r[0][1]['updated'][$jid]) ? $oldid : false;
+        }
+        $r = $this->client->call([
+            ['Calendar/set', ['accountId' => $this->accountId, 'create' => ['cal1' => ['name' => $name]]], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+        $newId = $r[0][1]['created']['cal1']['id'] ?? null;
+        return $newId ? self::PFX_CALENDAR . $newId : false;
+    }
+
+    private function deleteMailbox(string $id): bool {
+        $r = $this->client->call([
+            ['Mailbox/set', ['accountId' => $this->accountId, 'destroy' => [$id], 'onDestroyRemoveEmails' => true], '0'],
+        ]);
+        return in_array($id, $r[0][1]['destroyed'] ?? [], true);
+    }
+
+    private function deleteAddressBook(string $id): bool {
+        $jid = $this->jmapId($id);
+        $r   = $this->client->call([
+            ['AddressBook/set', ['accountId' => $this->accountId, 'destroy' => [$jid]], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+        return in_array($jid, $r[0][1]['destroyed'] ?? [], true);
+    }
+
+    private function deleteCalendar(string $id): bool {
+        $jid = $this->jmapId($id);
+        $r   = $this->client->call([
+            ['Calendar/set', ['accountId' => $this->accountId, 'destroy' => [$jid]], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+        return in_array($jid, $r[0][1]['destroyed'] ?? [], true);
+    }
+
+    // =========================================================================
+    // Private utility helpers
+    // =========================================================================
+
+    private function folderType(string $folderid): string {
+        if (str_starts_with($folderid, self::PFX_CONTACTS)) return 'contacts';
+        if (str_starts_with($folderid, self::PFX_CALENDAR)) return 'calendar';
+        return 'mail';
+    }
+
+    private function jmapId(string $folderid): string {
+        foreach ([self::PFX_CONTACTS, self::PFX_CALENDAR] as $pfx) {
+            if (str_starts_with($folderid, $pfx)) return substr($folderid, strlen($pfx));
+        }
+        return $folderid;
+    }
+
+    private function getAllMailboxes(): array {
+        $r = $this->client->call([
+            ['Mailbox/get', ['accountId' => $this->accountId, 'ids' => null], '0'],
+        ]);
+        return $r[0][1]['list'] ?? [];
+    }
+
+    private function getAllAddressBooks(): array {
+        $r = $this->client->call([
+            ['AddressBook/get', ['accountId' => $this->accountId, 'ids' => null], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+        return $r[0][1]['list'] ?? [];
+    }
+
+    private function getAllCalendars(): array {
+        $r = $this->client->call([
+            ['Calendar/get', ['accountId' => $this->accountId, 'ids' => null], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+        return $r[0][1]['list'] ?? [];
+    }
+
+    private function getFolderQueryState(string $folderid): string {
+        return match($this->folderType($folderid)) {
+            'contacts' => $this->contactQueryState($this->jmapId($folderid)),
+            'calendar' => $this->calendarQueryState($this->jmapId($folderid)),
+            default    => $this->emailQueryState($folderid),
+        };
+    }
+
+    private function emailQueryState(string $folderid): string {
+        $r = $this->client->call([
+            ['Email/query', ['accountId' => $this->accountId, 'filter' => ['inMailbox' => $folderid], 'limit' => 1], '0'],
+        ]);
+        return $r[0][1]['queryState'] ?? '';
+    }
+
+    private function contactQueryState(string $abId): string {
+        $r = $this->client->call([
+            ['ContactCard/query', ['accountId' => $this->accountId, 'filter' => ['inAddressBook' => $abId], 'limit' => 1], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CONTACTS]);
+        return $r[0][1]['queryState'] ?? '';
+    }
+
+    private function calendarQueryState(string $calId): string {
+        $r = $this->client->call([
+            ['CalendarEvent/query', ['accountId' => $this->accountId, 'filter' => ['inCalendar' => $calId], 'limit' => 1], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_CALENDARS]);
+        return $r[0][1]['queryState'] ?? '';
+    }
+
+    private function getIdentityId(): string {
+        if ($this->identityId === '') {
+            $this->identityId = $this->fetchPrimaryIdentityId();
+        }
+        return $this->identityId;
+    }
+
+    private function fetchPrimaryIdentityId(): string {
+        $r        = $this->client->call([
+            ['Identity/get', ['accountId' => $this->accountId, 'ids' => null], '0'],
+        ], [JmapClient::CAP_CORE, JmapClient::CAP_MAIL, JmapClient::CAP_SUBMIT]);
+        $identity = $r[0][1]['list'][0] ?? [];
+        $this->identityName = $identity['name'] ?? '';
+        return $identity['id'] ?? '';
+    }
+
+    private function getIdentityName(): string {
+        $this->getIdentityId(); // ensure lazy load
+        return $this->identityName;
+    }
+
+    private function rewriteFromHeader(string $mime, string $name): string {
+        $eol = str_contains($mime, "\r\n") ? "\r\n" : "\n";
+        $pattern = '/^(From:[ \t]*)(.+?)(?=' . preg_quote($eol, '/') . '(?![ \t]))/ms';
+        return preg_replace_callback($pattern, function ($m) use ($name, $eol) {
+            $val = preg_replace('/' . preg_quote($eol, '/') . '[ \t]+/', ' ', $m[2]);
+            if (preg_match('/<([^>]+)>/', $val, $em)) {
+                $email = $em[1];
+            } elseif (preg_match('/\S+@\S+/', $val, $em)) {
+                $email = trim($em[0]);
+            } else {
+                return $m[0];
+            }
+            $quotedName = str_replace(['"', '\\'], ['\\"', '\\\\'], $name);
+            return 'From: "' . $quotedName . '" <' . $email . '>';
+        }, $mime);
+    }
+
+    private function getMailboxIdByRole(string $role): string|false {
+        foreach ($this->getAllMailboxes() as $mb) {
+            if (($mb['role'] ?? '') === $role) return $mb['id'];
+        }
+        return false;
+    }
+
+    private function getSentMailboxId(): string|false {
+        return $this->getMailboxIdByRole('sent');
+    }
+
+    private function setKeywords(string $emailId, array $keywords): bool {
+        $patch = [];
+        foreach ($keywords as $kw => $value) {
+            $patch["keywords/$kw"] = $value ?: null;
+        }
+        $r = $this->client->call([
+            ['Email/set', ['accountId' => $this->accountId, 'update' => [$emailId => $patch]], '0'],
+        ]);
+        return isset($r[0][1]['updated'][$emailId]);
+    }
+
+    private function formatAddressList(array $addresses): string {
+        $parts = [];
+        foreach ($addresses as $addr) {
+            $email = $addr['email'] ?? '';
+            $name  = $addr['name']  ?? '';
+            $parts[] = $name ? '"' . addslashes($name) . '" <' . $email . '>' : $email;
+        }
+        return implode(', ', $parts);
+    }
+
+    private function parseJmapDate(string $date): int {
+        if (!$date) return 0;
+        $dt = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC3339, $date, new \DateTimeZone('UTC'));
+        return $dt ? $dt->getTimestamp() : 0;
+    }
+
+    private function keywordsHash(array $keywords): string {
+        $keys = array_keys($keywords);
+        sort($keys);
+        return sprintf('%08x', crc32(implode(',', $keys)));
+    }
+
+    private function extToMime(string $ext): string {
+        static $map = [
+            'pdf' => 'application/pdf', 'jpg' => 'image/jpeg', 'jpeg' => 'image/jpeg',
+            'png' => 'image/png', 'gif' => 'image/gif', 'txt' => 'text/plain',
+            'html' => 'text/html', 'htm' => 'text/html', 'zip' => 'application/zip',
+            'doc' => 'application/msword',
+            'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'xls' => 'application/vnd.ms-excel',
+            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'ics' => 'text/calendar', 'vcf' => 'text/vcard', 'eml' => 'message/rfc822',
+        ];
+        return $map[$ext] ?? 'application/octet-stream';
+    }
+}

--- a/src/backend/jmap/jmap_calendar.php
+++ b/src/backend/jmap/jmap_calendar.php
@@ -1,0 +1,392 @@
+<?php
+/***********************************************
+* File      :   jmap_calendar.php
+* Project   :   Z-Push
+* Descr     :   JSCalendar (RFC 8984) <-> SyncAppointment conversion
+*               for the JMAP backend. No external dependencies.
+*
+* Copyright 2024 - Z-Push Contributors
+* AGPL-3.0 - see LICENSE
+************************************************/
+
+class JmapCalendarConverter {
+
+    // -------------------------------------------------------------------------
+    // JSCalendar Event → SyncAppointment
+    // -------------------------------------------------------------------------
+
+    public static function eventToSyncAppointment(array $event): SyncAppointment {
+        $a = new SyncAppointment();
+
+        $a->subject = $event['title'] ?? '(No Subject)';
+        $a->uid     = $event['uid']   ?? '';
+
+        // Time
+        $tz    = $event['timeZone'] ?? 'UTC';
+        $start = $event['start']    ?? '';
+        $startTs = $start ? self::localToTimestamp($start, $tz) : time();
+        $durSecs = self::parseDuration($event['duration'] ?? 'PT1H');
+
+        $a->starttime   = $startTs;
+        $a->endtime     = $startTs + $durSecs;
+        $a->alldayevent = !empty($event['showWithoutTime']) ? 1 : 0;
+
+        // Description / body
+        if (!empty($event['description'])) {
+            $desc = $event['description'];
+            $a->asbody = new SyncBaseBody();
+            $a->asbody->type              = SYNC_BODYPREFERENCE_PLAIN;
+            $a->asbody->data              = StringStreamWrapper::Open($desc);
+            $a->asbody->estimatedDataSize = strlen($desc);
+            $a->asbody->truncated         = 0;
+        }
+
+        // Location
+        $locations = array_values($event['locations'] ?? []);
+        if ($locations) $a->location = $locations[0]['name'] ?? null;
+
+        // Organizer + attendees
+        $attendees = [];
+        foreach ($event['participants'] ?? [] as $p) {
+            $roles = $p['roles'] ?? [];
+            $name  = $p['name']  ?? '';
+            $email = $p['email'] ?? $p['sendTo']['imip'] ?? '';
+
+            if (isset($roles['organizer'])) {
+                $a->organizername  = $name;
+                $a->organizeremail = $email;
+            } else {
+                $att = new SyncAttendee();
+                $att->name  = $name;
+                $att->email = $email;
+
+                $att->attendeestatus = match(strtolower($p['participationStatus'] ?? 'needs-action')) {
+                    'accepted'  => 3,
+                    'declined'  => 4,
+                    'tentative' => 2,
+                    default     => 0,
+                };
+                $att->attendeetype = match(true) {
+                    isset($roles['optional'])      => 2,
+                    isset($roles['informational']) => 3,
+                    default                        => 1,
+                };
+                $attendees[] = $att;
+            }
+        }
+        if ($attendees) {
+            $a->attendees    = $attendees;
+            $a->meetingstatus = 1;
+        }
+
+        // Sensitivity
+        $a->sensitivity = match($event['privacy'] ?? 'public') {
+            'private', 'secret' => 2,
+            'confidential'      => 3,
+            default             => 0,
+        };
+
+        // Free/busy
+        $a->busystatus = match($event['freeBusyStatus'] ?? 'busy') {
+            'free'        => 0,
+            'tentative'   => 1,
+            'unavailable' => 3,
+            default       => 2,
+        };
+
+        // Reminder (first alert with negative offset)
+        foreach ($event['alerts'] ?? [] as $alert) {
+            $offset = $alert['trigger']['offset'] ?? null;
+            if ($offset && str_starts_with($offset, '-')) {
+                $secs = self::parseDuration(ltrim($offset, '-'));
+                $a->reminder = max(0, (int)($secs / 60));
+                break;
+            }
+        }
+
+        // Recurrence
+        $rules = $event['recurrenceRules'] ?? [];
+        if ($rules) {
+            $a->recurrence = self::jmapRuleToSyncRecurrence($rules[0]);
+        }
+
+        // Categories
+        $cats = array_keys($event['categories'] ?? []);
+        if ($cats) $a->categories = $cats;
+
+        return $a;
+    }
+
+    // -------------------------------------------------------------------------
+    // SyncAppointment → JSCalendar Event
+    // -------------------------------------------------------------------------
+
+    public static function syncAppointmentToEvent(SyncAppointment $a, string $calendarId): array {
+        $startTs = $a->starttime ?? time();
+        $endTs   = $a->endtime   ?? ($startTs + 3600);
+        $allDay  = !empty($a->alldayevent);
+
+        $event = [
+            '@type'       => 'Event',
+            'calendarIds' => [$calendarId => true],
+            'title'       => $a->subject ?? '(No Subject)',
+            'uid'         => !empty($a->uid) ? $a->uid : self::newUid(),
+        ];
+
+        if ($allDay) {
+            $event['showWithoutTime'] = true;
+            $event['start']           = gmdate('Y-m-d', $startTs);
+            $event['duration']        = 'P' . max(1, intdiv($endTs - $startTs, 86400)) . 'D';
+            $event['timeZone']        = 'UTC';
+        } else {
+            $event['start']    = gmdate('Y-m-d\TH:i:s', $startTs);
+            $event['duration'] = self::secondsToDuration($endTs - $startTs);
+            $event['timeZone'] = 'UTC';
+        }
+
+        // Location
+        if (!empty($a->location)) {
+            $event['locations'] = ['l1' => ['@type' => 'Location', 'name' => $a->location]];
+        }
+
+        // Description
+        if (!empty($a->body)) {
+            $event['description'] = $a->body;
+        }
+
+        // Organizer + attendees
+        $participants = [];
+        if (!empty($a->organizeremail)) {
+            $participants['org'] = [
+                '@type' => 'Participant',
+                'name'  => $a->organizername ?? $a->organizeremail,
+                'email' => $a->organizeremail,
+                'roles' => ['organizer' => true, 'attendee' => true],
+            ];
+        }
+        foreach ($a->attendees ?? [] as $i => $att) {
+            $participants['att' . $i] = [
+                '@type'               => 'Participant',
+                'name'                => $att->name  ?? '',
+                'email'               => $att->email ?? '',
+                'roles'               => match((int)($att->attendeetype ?? 1)) {
+                    2 => ['optional'      => true],
+                    3 => ['informational' => true],
+                    default => ['attendee'  => true],
+                },
+                'participationStatus' => match((int)($att->attendeestatus ?? 0)) {
+                    3 => 'accepted',
+                    4 => 'declined',
+                    2 => 'tentative',
+                    default => 'needs-action',
+                },
+            ];
+        }
+        if ($participants) $event['participants'] = $participants;
+
+        // Sensitivity
+        $event['privacy'] = match((int)($a->sensitivity ?? 0)) {
+            2, 1 => 'private',
+            3    => 'secret',
+            default => 'public',
+        };
+
+        // Free/busy
+        $event['freeBusyStatus'] = match((int)($a->busystatus ?? 2)) {
+            0 => 'free',
+            1 => 'tentative',
+            3 => 'unavailable',
+            default => 'busy',
+        };
+
+        // Reminder
+        if (!empty($a->reminder)) {
+            $mins = (int)$a->reminder;
+            $event['alerts'] = ['al1' => [
+                '@type'   => 'Alert',
+                'trigger' => [
+                    '@type'      => 'OffsetTrigger',
+                    'offset'     => '-PT' . $mins . 'M',
+                    'relativeTo' => 'start',
+                ],
+                'action'  => 'display',
+            ]];
+        }
+
+        // Recurrence
+        if (!empty($a->recurrence)) {
+            $rule = self::syncRecurrenceToJmap($a->recurrence);
+            if ($rule) $event['recurrenceRules'] = [$rule];
+        }
+
+        // Categories
+        if (!empty($a->categories)) {
+            $cats = [];
+            foreach ($a->categories as $cat) $cats[$cat] = true;
+            $event['categories'] = $cats;
+        }
+
+        return $event;
+    }
+
+    // -------------------------------------------------------------------------
+    // Mod hash for change detection
+    // -------------------------------------------------------------------------
+
+    public static function eventModHash(array $event): string {
+        $key = ($event['title'] ?? '') .
+               ($event['start'] ?? '') .
+               ($event['duration'] ?? '') .
+               ($event['updated'] ?? '');
+        return sprintf('%08x', crc32($key));
+    }
+
+    // -------------------------------------------------------------------------
+    // Recurrence helpers
+    // -------------------------------------------------------------------------
+
+    private static function jmapRuleToSyncRecurrence(array $rule): SyncRecurrence {
+        $r = new SyncRecurrence();
+
+        $freq   = strtolower($rule['frequency'] ?? 'daily');
+        $byDay  = $rule['byDay']      ?? [];
+        $byPos  = $rule['bySetPosition'] ?? [];
+
+        // Monthly nth-day vs plain monthly
+        if ($freq === 'monthly' && $byDay && $byPos) {
+            $r->type = 3; // Monthly nth day
+        } elseif ($freq === 'yearly' && ($byDay || $byPos)) {
+            $r->type = 6;
+        } else {
+            $r->type = match($freq) {
+                'daily'   => 0,
+                'weekly'  => 1,
+                'monthly' => 2,
+                'yearly'  => 5,
+                default   => 0,
+            };
+        }
+
+        $r->interval = max(1, (int)($rule['interval'] ?? 1));
+
+        if (!empty($rule['count'])) {
+            $r->occurrences = (int)$rule['count'];
+        } elseif (!empty($rule['until'])) {
+            $r->until = self::localToTimestamp($rule['until'], 'UTC');
+        }
+
+        // Day-of-week bitmask
+        if ($byDay) {
+            $map  = ['su' => 1, 'mo' => 2, 'tu' => 4, 'we' => 8, 'th' => 16, 'fr' => 32, 'sa' => 64];
+            $mask = 0;
+            foreach ($byDay as $d) {
+                $mask |= $map[strtolower($d['day'] ?? '')] ?? 0;
+            }
+            if ($mask) $r->dayofweek = $mask;
+
+            // nth occurrence within month
+            if ($byPos) {
+                $r->weekofmonth = (int)$byPos[0] === -1 ? 5 : (int)$byPos[0];
+            }
+        }
+
+        if (!empty($rule['byMonthDay'])) $r->dayofmonth  = (int)$rule['byMonthDay'][0];
+        if (!empty($rule['byMonth']))    $r->monthofyear = (int)$rule['byMonth'][0];
+
+        return $r;
+    }
+
+    private static function syncRecurrenceToJmap(SyncRecurrence $r): ?array {
+        $type = (int)($r->type ?? 0);
+        $rule = [
+            '@type'     => 'RecurrenceRule',
+            'frequency' => match($type) {
+                0    => 'daily',
+                1    => 'weekly',
+                2, 3 => 'monthly',
+                5, 6 => 'yearly',
+                default => 'daily',
+            },
+        ];
+
+        if (!empty($r->interval) && $r->interval > 1) $rule['interval'] = (int)$r->interval;
+
+        if (!empty($r->occurrences)) {
+            $rule['count'] = (int)$r->occurrences;
+        } elseif (!empty($r->until)) {
+            $rule['until'] = gmdate('Y-m-d', $r->until);
+        }
+
+        if (!empty($r->dayofweek)) {
+            $map = [1 => 'su', 2 => 'mo', 4 => 'tu', 8 => 'we', 16 => 'th', 32 => 'fr', 64 => 'sa'];
+            $byDay = [];
+            $nDay  = [];
+            foreach ($map as $bit => $day) {
+                if ($r->dayofweek & $bit) {
+                    $entry = ['@type' => 'NDay', 'day' => $day];
+                    $byDay[] = $entry;
+                    $nDay[]  = $day;
+                }
+            }
+            $rule['byDay'] = $byDay;
+            if (!empty($r->weekofmonth)) {
+                $rule['bySetPosition'] = [$r->weekofmonth === 5 ? -1 : (int)$r->weekofmonth];
+            }
+        }
+
+        if (!empty($r->dayofmonth))  $rule['byMonthDay'] = [(int)$r->dayofmonth];
+        if (!empty($r->monthofyear)) $rule['byMonth']    = [(string)(int)$r->monthofyear];
+
+        return $rule;
+    }
+
+    // -------------------------------------------------------------------------
+    // Time utilities
+    // -------------------------------------------------------------------------
+
+    public static function localToTimestamp(string $datetime, string $tz): int {
+        try {
+            $dt = new \DateTime($datetime, new \DateTimeZone($tz));
+            return $dt->getTimestamp();
+        } catch (\Throwable) {
+            return 0;
+        }
+    }
+
+    public static function parseDuration(string $duration): int {
+        $neg = str_starts_with($duration, '-');
+        $d   = ltrim($duration, '-');
+        if (!preg_match('/^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/', $d, $m)) {
+            return 0;
+        }
+        $secs = (int)($m[1] ?? 0) * 365 * 86400
+              + (int)($m[2] ?? 0) * 30  * 86400
+              + (int)($m[3] ?? 0) * 7   * 86400
+              + (int)($m[4] ?? 0)       * 86400
+              + (int)($m[5] ?? 0)       * 3600
+              + (int)($m[6] ?? 0)       * 60
+              + (int)($m[7] ?? 0);
+        return $neg ? -$secs : $secs;
+    }
+
+    private static function secondsToDuration(int $seconds): string {
+        if ($seconds <= 0) return 'PT0S';
+        $days  = intdiv($seconds, 86400); $rem = $seconds % 86400;
+        $hours = intdiv($rem, 3600);      $rem %= 3600;
+        $mins  = intdiv($rem, 60);
+        $secs  = $rem % 60;
+
+        $s = 'P';
+        if ($days)  $s .= $days  . 'D';
+        $t = '';
+        if ($hours) $t .= $hours . 'H';
+        if ($mins)  $t .= $mins  . 'M';
+        if ($secs)  $t .= $secs  . 'S';
+        if ($t)     $s .= 'T' . $t;
+        return $s ?: 'PT0S';
+    }
+
+    private static function newUid(): string {
+        return sprintf('%s@zpush-jmap', bin2hex(random_bytes(16)));
+    }
+}

--- a/src/backend/jmap/jmap_client.php
+++ b/src/backend/jmap/jmap_client.php
@@ -1,0 +1,215 @@
+<?php
+/***********************************************
+* File      :   jmap_client.php
+* Project   :   Z-Push
+* Descr     :   Pure PHP JMAP HTTP client.
+*               Handles session bootstrapping, API calls, blob
+*               upload and download.
+*
+* Copyright 2024 - Z-Push Contributors
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License, version 3,
+* as published by the Free Software Foundation.
+*
+* Consult LICENSE file for details
+************************************************/
+
+class JmapClient {
+
+    private string $sessionUrl;
+    private string $username;
+    private string $password;
+    private ?array $session = null;
+
+    // Capability URNs
+    const CAP_CORE       = 'urn:ietf:params:jmap:core';
+    const CAP_MAIL       = 'urn:ietf:params:jmap:mail';
+    const CAP_SUBMIT     = 'urn:ietf:params:jmap:submission';
+    const CAP_VACATION   = 'urn:ietf:params:jmap:vacationresponse';
+    const CAP_CONTACTS   = 'urn:ietf:params:jmap:contacts';
+    const CAP_CALENDARS  = 'urn:ietf:params:jmap:calendars';
+
+    public function __construct(string $sessionUrl, string $username, string $password) {
+        $this->sessionUrl = $sessionUrl;
+        $this->username   = $username;
+        $this->password   = $password;
+    }
+
+    /**
+     * Fetch and cache the JMAP session object.
+     * Throws FatalException if the server is unreachable or auth fails.
+     */
+    public function getSession(): array {
+        if ($this->session === null) {
+            $this->session = $this->httpRequest('GET', $this->sessionUrl);
+        }
+        return $this->session;
+    }
+
+    /**
+     * Invalidate the cached session so the next call re-fetches it.
+     */
+    public function invalidateSession(): void {
+        $this->session = null;
+    }
+
+    /**
+     * Return the accountId for the mail capability.
+     */
+    public function getAccountId(): string {
+        $session = $this->getSession();
+        if (!isset($session['primaryAccounts'][self::CAP_MAIL])) {
+            throw new FatalException('JmapClient: no mail account in JMAP session', 0, null, LOGLEVEL_FATAL);
+        }
+        return $session['primaryAccounts'][self::CAP_MAIL];
+    }
+
+    /**
+     * Return the JMAP API URL from the session.
+     */
+    public function getApiUrl(): string {
+        return $this->getSession()['apiUrl'];
+    }
+
+    /**
+     * Return the session state string (used for change detection).
+     */
+    public function getSessionState(): string {
+        return $this->getSession()['state'] ?? '';
+    }
+
+    /**
+     * Execute a JMAP method-call batch.
+     *
+     * @param array $methodCalls  Array of [methodName, arguments, callId] triples.
+     * @param array $using        Capability URNs. Defaults to core + mail.
+     * @return array              methodResponses array from the JMAP response.
+     */
+    public function call(array $methodCalls, array $using = [self::CAP_CORE, self::CAP_MAIL]): array {
+        $payload = json_encode([
+            'using'       => array_values($using),
+            'methodCalls' => $methodCalls,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $response = $this->httpRequest('POST', $this->getApiUrl(), $payload, 'application/json');
+
+        if (!isset($response['methodResponses'])) {
+            throw new StatusException('JmapClient: JMAP response missing methodResponses', SYNC_STATUS_SERVERERROR);
+        }
+        return $response['methodResponses'];
+    }
+
+    /**
+     * Upload binary data and return the blobId.
+     *
+     * @param string $data         Raw binary data.
+     * @param string $contentType  MIME type of the blob.
+     * @return string              The blobId assigned by the server.
+     */
+    public function uploadBlob(string $data, string $contentType = 'message/rfc822'): string {
+        $accountId = $this->getAccountId();
+        $url       = str_replace('{accountId}', rawurlencode($accountId), $this->getSession()['uploadUrl']);
+        $result    = $this->httpRequest('POST', $url, $data, $contentType);
+
+        if (!isset($result['blobId'])) {
+            throw new StatusException('JmapClient: upload response missing blobId', SYNC_STATUS_SERVERERROR);
+        }
+        return $result['blobId'];
+    }
+
+    /**
+     * Download a blob and return its raw bytes.
+     *
+     * @param string $blobId    The blobId to download.
+     * @param string $name      Suggested filename (used in URL template).
+     * @param string $accept    Accepted content type.
+     * @return string           Raw blob data.
+     */
+    public function downloadBlob(string $blobId, string $name = 'attachment', string $accept = 'application/octet-stream'): string {
+        $accountId = $this->getAccountId();
+        $url = $this->getSession()['downloadUrl'];
+        $url = str_replace(
+            ['{accountId}', '{blobId}', '{name}',           '{type}'],
+            [rawurlencode($accountId), rawurlencode($blobId), rawurlencode($name), rawurlencode($accept)],
+            $url
+        );
+        return $this->httpRequest('GET', $url, null, null, true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Perform an HTTP request and return the decoded JSON body (or raw string).
+     *
+     * @param string      $method       HTTP verb.
+     * @param string      $url          Full URL.
+     * @param string|null $body         Request body (null for GET).
+     * @param string|null $contentType  Content-Type header value.
+     * @param bool        $rawResponse  Return raw bytes instead of decoded JSON.
+     * @return mixed
+     * @throws FatalException|StatusException on HTTP / decode errors.
+     */
+    private function httpRequest(
+        string $method,
+        string $url,
+        ?string $body = null,
+        ?string $contentType = null,
+        bool $rawResponse = false
+    ): mixed {
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_USERPWD        => $this->username . ':' . $this->password,
+            CURLOPT_TIMEOUT        => JMAP_TIMEOUT,
+            CURLOPT_SSL_VERIFYPEER => JMAP_SSL_VERIFY,
+            CURLOPT_SSL_VERIFYHOST => JMAP_SSL_VERIFY ? 2 : 0,
+            CURLOPT_USERAGENT      => 'Z-Push JMAP Backend/1.0',
+        ]);
+
+        $headers = ['Accept: application/json'];
+        if ($contentType !== null) {
+            $headers[] = 'Content-Type: ' . $contentType;
+        }
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+        if ($method === 'POST') {
+            curl_setopt($ch, CURLOPT_POST, true);
+            if ($body !== null) {
+                curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+            }
+        }
+
+        $responseBody = curl_exec($ch);
+        $httpCode     = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError    = curl_error($ch);
+        curl_close($ch);
+
+        if ($curlError) {
+            throw new FatalException(
+                sprintf('JmapClient: cURL error for %s %s: %s', $method, $url, $curlError),
+                0, null, LOGLEVEL_ERROR
+            );
+        }
+
+        if ($httpCode === 401) {
+            throw new AuthenticationRequiredException('JmapClient: authentication failed (401)');
+        }
+
+        if ($httpCode >= 400) {
+            throw new StatusException(
+                sprintf('JmapClient: HTTP %d from %s %s: %s', $httpCode, $method, $url, substr($responseBody, 0, 200)),
+                SYNC_STATUS_SERVERERROR
+            );
+        }
+
+        if ($rawResponse) {
+            return $responseBody;
+        }
+
+        $decoded = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
+    }
+}

--- a/src/backend/jmap/jmap_contacts.php
+++ b/src/backend/jmap/jmap_contacts.php
@@ -1,0 +1,338 @@
+<?php
+/***********************************************
+* File      :   jmap_contacts.php
+* Project   :   Z-Push
+* Descr     :   JSContact (RFC 9553) <-> SyncContact conversion for
+*               the JMAP backend. No external dependencies.
+*
+* Copyright 2024 - Z-Push Contributors
+* AGPL-3.0 - see LICENSE
+************************************************/
+
+class JmapContactConverter {
+
+    // -------------------------------------------------------------------------
+    // JSContact → SyncContact
+    // -------------------------------------------------------------------------
+
+    public static function cardToSyncContact(array $card): SyncContact {
+        $c = new SyncContact();
+
+        // Name
+        $name = $card['name'] ?? [];
+        $c->firstname  = $name['given']      ?? null;
+        $c->lastname   = $name['surname']    ?? null;
+        $c->middlename = $name['additional'] ?? null;
+        $c->title      = $name['prefix']     ?? null;
+        $c->suffix     = $name['suffix']     ?? null;
+        $full          = $name['full']       ?? null;
+        $c->fileas     = $full ?: trim(($c->firstname ?? '') . ' ' . ($c->lastname ?? '')) ?: null;
+
+        // Nicknames
+        $nicks = array_values($card['nicknames'] ?? []);
+        if ($nicks) $c->nickname = $nicks[0]['name'] ?? null;
+
+        // Emails — work first, then home, then any
+        $emails = array_values($card['emails'] ?? []);
+        usort($emails, fn($a, $b) =>
+            (int)isset($b['contexts']['work']) - (int)isset($a['contexts']['work'])
+        );
+        foreach ($emails as $i => $e) {
+            match ($i) {
+                0 => $c->email1address = $e['address'] ?? null,
+                1 => $c->email2address = $e['address'] ?? null,
+                2 => $c->email3address = $e['address'] ?? null,
+                default => null,
+            };
+        }
+
+        // Phones — classify by context/features
+        foreach (array_values($card['phones'] ?? []) as $p) {
+            $num      = $p['number']   ?? '';
+            $ctx      = $p['contexts'] ?? [];
+            $features = $p['features'] ?? [];
+
+            if (isset($features['cell']) || isset($features['mobile'])) {
+                $c->mobilephonenumber ??= $num;
+            } elseif (isset($features['fax'])) {
+                if (isset($ctx['work'])) $c->businessfaxnumber ??= $num;
+                else                     $c->homefaxnumber     ??= $num;
+            } elseif (isset($features['pager'])) {
+                $c->pagernumber ??= $num;
+            } elseif (isset($ctx['work'])) {
+                if (!isset($c->businessphonenumber)) $c->businessphonenumber  = $num;
+                else                                  $c->business2phonenumber ??= $num;
+            } elseif (isset($ctx['home'])) {
+                if (!isset($c->homephonenumber)) $c->homephonenumber  = $num;
+                else                              $c->home2phonenumber ??= $num;
+            } else {
+                $c->mobilephonenumber ??= $num;
+            }
+        }
+
+        // Addresses
+        foreach (array_values($card['addresses'] ?? []) as $addr) {
+            $ctx    = $addr['contexts'] ?? [];
+            $parsed = self::parseAddressComponents($addr['components'] ?? []);
+            if (isset($ctx['work'])) {
+                $c->businessstreet     ??= $parsed['street'];
+                $c->businesscity       ??= $parsed['city'];
+                $c->businessstate      ??= $parsed['state'];
+                $c->businesspostalcode ??= $parsed['postal'];
+                $c->businesscountry    ??= $parsed['country'];
+            } elseif (isset($ctx['home'])) {
+                $c->homestreet     ??= $parsed['street'];
+                $c->homecity       ??= $parsed['city'];
+                $c->homestate      ??= $parsed['state'];
+                $c->homepostalcode ??= $parsed['postal'];
+                $c->homecountry    ??= $parsed['country'];
+            } else {
+                $c->otherstreet     ??= $parsed['street'];
+                $c->othercity       ??= $parsed['city'];
+                $c->otherstate      ??= $parsed['state'];
+                $c->otherpostalcode ??= $parsed['postal'];
+                $c->othercountry    ??= $parsed['country'];
+            }
+        }
+
+        // Organization, job title, department
+        $orgs   = array_values($card['organizations'] ?? []);
+        $titles = array_values($card['jobTitles']     ?? []);
+        $depts  = array_values($card['departments']   ?? []);
+        if ($orgs)   $c->companyname = $orgs[0]['name']   ?? null;
+        if ($titles) $c->jobtitle    = $titles[0]['name'] ?? null;
+        if ($depts)  $c->department  = $depts[0]['name']  ?? null;
+
+        // URLs
+        foreach (array_values($card['links'] ?? []) as $link) {
+            $c->webpage ??= $link['uri'] ?? null;
+        }
+
+        // IM
+        $ims = array_values($card['onlineServices'] ?? []);
+        foreach ($ims as $i => $im) {
+            $val = $im['uri'] ?? $im['service'] ?? null;
+            match ($i) {
+                0 => $c->imaddress  = $val,
+                1 => $c->imaddress2 = $val,
+                2 => $c->imaddress3 = $val,
+                default => null,
+            };
+        }
+
+        // Anniversaries
+        foreach ($card['anniversaries'] ?? [] as $ann) {
+            $date = self::formatAnniversaryDate($ann['date'] ?? null);
+            if (!$date) continue;
+            if (str_contains(strtolower($ann['type'] ?? 'birth'), 'birth')) {
+                $c->birthday    ??= $date;
+            } else {
+                $c->anniversary ??= $date;
+            }
+        }
+
+        // Notes → body / asbody
+        $notes = array_values($card['notes'] ?? []);
+        if ($notes) {
+            $text = $notes[0]['note'] ?? '';
+            $c->asbody = new SyncBaseBody();
+            $c->asbody->type              = SYNC_BODYPREFERENCE_PLAIN;
+            $c->asbody->data              = StringStreamWrapper::Open($text);
+            $c->asbody->estimatedDataSize = strlen($text);
+            $c->asbody->truncated         = 0;
+        }
+
+        // Categories
+        if (!empty($card['categories'])) {
+            $c->categories = array_keys($card['categories']);
+        }
+
+        // Relations
+        foreach ($card['relations'] ?? [] as $rel) {
+            $roles = $rel['relation'] ?? [];
+            $name  = $rel['name']    ?? '';
+            if (isset($roles['spouse']))    $c->spouse        ??= $name;
+            if (isset($roles['manager']))   $c->managername   ??= $name;
+            if (isset($roles['assistant'])) $c->assistantname ??= $name;
+        }
+
+        return $c;
+    }
+
+    // -------------------------------------------------------------------------
+    // SyncContact → JSContact
+    // -------------------------------------------------------------------------
+
+    public static function syncContactToCard(SyncContact $c, string $addressBookId): array {
+        $card = [
+            '@type'          => 'Card',
+            'version'        => '1.0',
+            'addressBookIds' => [$addressBookId => true],
+        ];
+
+        // Name
+        $nameParts = array_filter([
+            'given'      => $c->firstname  ?? null,
+            'surname'    => $c->lastname   ?? null,
+            'additional' => $c->middlename ?? null,
+            'prefix'     => $c->title      ?? null,
+            'suffix'     => $c->suffix     ?? null,
+            'full'       => $c->fileas     ?? trim(($c->firstname ?? '') . ' ' . ($c->lastname ?? '')) ?: null,
+        ]);
+        if ($nameParts) $card['name'] = $nameParts;
+
+        if (!empty($c->nickname)) {
+            $card['nicknames'] = ['n1' => ['name' => $c->nickname]];
+        }
+
+        // Emails
+        $emails = [];
+        if (!empty($c->email1address)) $emails['e1'] = ['address' => $c->email1address, 'contexts' => ['work' => true]];
+        if (!empty($c->email2address)) $emails['e2'] = ['address' => $c->email2address, 'contexts' => ['home' => true]];
+        if (!empty($c->email3address)) $emails['e3'] = ['address' => $c->email3address];
+        if ($emails) $card['emails'] = $emails;
+
+        // Phones
+        $phones = [];
+        $pi = 1;
+        foreach ([
+            [$c->businessphonenumber  ?? null, ['work' => true],  []],
+            [$c->business2phonenumber ?? null, ['work' => true],  []],
+            [$c->homephonenumber      ?? null, ['home' => true],  []],
+            [$c->home2phonenumber     ?? null, ['home' => true],  []],
+            [$c->mobilephonenumber    ?? null, [],                ['cell' => true]],
+            [$c->businessfaxnumber    ?? null, ['work' => true],  ['fax'  => true]],
+            [$c->homefaxnumber        ?? null, ['home' => true],  ['fax'  => true]],
+            [$c->pagernumber          ?? null, [],                ['pager'=> true]],
+            [$c->carphonenumber       ?? null, ['other' => true], []],
+        ] as [$num, $ctx, $feat]) {
+            if (!$num) continue;
+            $entry = ['number' => $num];
+            if ($ctx)  $entry['contexts'] = $ctx;
+            if ($feat) $entry['features'] = $feat;
+            $phones['p' . $pi++] = $entry;
+        }
+        if ($phones) $card['phones'] = $phones;
+
+        // Addresses
+        $addrs = [];
+        if (!empty($c->businessstreet) || !empty($c->businesscity)) {
+            $addrs['a1'] = self::buildAddress($c->businessstreet, $c->businesscity, $c->businessstate, $c->businesspostalcode, $c->businesscountry, 'work');
+        }
+        if (!empty($c->homestreet) || !empty($c->homecity)) {
+            $addrs['a2'] = self::buildAddress($c->homestreet, $c->homecity, $c->homestate, $c->homepostalcode, $c->homecountry, 'home');
+        }
+        if (!empty($c->otherstreet) || !empty($c->othercity)) {
+            $addrs['a3'] = self::buildAddress($c->otherstreet, $c->othercity, $c->otherstate, $c->otherpostalcode, $c->othercountry, null);
+        }
+        if ($addrs) $card['addresses'] = $addrs;
+
+        // Organization / job / department
+        if (!empty($c->companyname)) $card['organizations'] = ['o1' => ['name' => $c->companyname]];
+        if (!empty($c->jobtitle))    $card['jobTitles']     = ['jt1' => ['name' => $c->jobtitle]];
+        if (!empty($c->department))  $card['departments']   = ['d1'  => ['name' => $c->department]];
+
+        // URL
+        if (!empty($c->webpage)) {
+            $card['links'] = ['l1' => ['@type' => 'Link', 'uri' => $c->webpage]];
+        }
+
+        // IM
+        $ims = [];
+        if (!empty($c->imaddress))  $ims['im1'] = ['uri' => $c->imaddress];
+        if (!empty($c->imaddress2)) $ims['im2'] = ['uri' => $c->imaddress2];
+        if (!empty($c->imaddress3)) $ims['im3'] = ['uri' => $c->imaddress3];
+        if ($ims) $card['onlineServices'] = $ims;
+
+        // Anniversaries
+        $anns = [];
+        if (!empty($c->birthday))    $anns['b1'] = ['type' => 'birth',       'date' => self::toPartialDate($c->birthday)];
+        if (!empty($c->anniversary)) $anns['a1'] = ['type' => 'anniversary', 'date' => self::toPartialDate($c->anniversary)];
+        if ($anns) $card['anniversaries'] = $anns;
+
+        // Notes
+        if (!empty($c->body)) {
+            $card['notes'] = ['n1' => ['note' => $c->body]];
+        }
+
+        // Categories
+        if (!empty($c->categories)) {
+            $cats = [];
+            foreach ($c->categories as $cat) $cats[$cat] = true;
+            $card['categories'] = $cats;
+        }
+
+        // Relations
+        $rels = [];
+        if (!empty($c->spouse))        $rels['r1'] = ['name' => $c->spouse,        'relation' => ['spouse'    => true]];
+        if (!empty($c->managername))   $rels['r2'] = ['name' => $c->managername,   'relation' => ['manager'   => true]];
+        if (!empty($c->assistantname)) $rels['r3'] = ['name' => $c->assistantname, 'relation' => ['assistant' => true]];
+        if ($rels) $card['relations'] = $rels;
+
+        return $card;
+    }
+
+    // -------------------------------------------------------------------------
+    // Build a mod hash for change detection
+    // -------------------------------------------------------------------------
+
+    public static function cardModHash(array $card): string {
+        $key = ($card['name']['full'] ?? '') .
+               ($card['emails']['e1']['address'] ?? array_key_first($card['emails'] ?? []) ?? '') .
+               ($card['phones']['p1']['number']  ?? '') .
+               ($card['updated'] ?? '');
+        return sprintf('%08x', crc32($key));
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private static function parseAddressComponents(array $components): array {
+        $r = ['street' => '', 'city' => '', 'state' => '', 'postal' => '', 'country' => ''];
+        foreach ($components as $comp) {
+            $v = $comp['value'] ?? '';
+            match ($comp['kind'] ?? '') {
+                'name', 'number', 'street' => $r['street']  .= ($r['street'] ? ', ' : '') . $v,
+                'locality'                 => $r['city']     = $v,
+                'region'                   => $r['state']    = $v,
+                'postcode', 'postalCode'   => $r['postal']   = $v,
+                'country', 'countryName'   => $r['country']  = $v,
+                default                    => null,
+            };
+        }
+        return $r;
+    }
+
+    private static function buildAddress(?string $street, ?string $city, ?string $state, ?string $postal, ?string $country, ?string $context): array {
+        $components = [];
+        if ($street)  $components[] = ['kind' => 'street',   'value' => $street];
+        if ($city)    $components[] = ['kind' => 'locality', 'value' => $city];
+        if ($state)   $components[] = ['kind' => 'region',   'value' => $state];
+        if ($postal)  $components[] = ['kind' => 'postcode', 'value' => $postal];
+        if ($country) $components[] = ['kind' => 'country',  'value' => $country];
+
+        $addr = ['@type' => 'Address', 'components' => $components];
+        if ($context) $addr['contexts'] = [$context => true];
+        return $addr;
+    }
+
+    private static function formatAnniversaryDate(mixed $date): ?string {
+        if (!$date) return null;
+        if (is_string($date)) return $date;
+        if (is_array($date)) {
+            $y = $date['year']  ?? 0;
+            $m = $date['month'] ?? 1;
+            $d = $date['day']   ?? 1;
+            return sprintf('%04d-%02d-%02d', $y, $m, $d);
+        }
+        return null;
+    }
+
+    private static function toPartialDate(string $date): array {
+        if (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $date, $m)) {
+            return ['@type' => 'PartialDate', 'year' => (int)$m[1], 'month' => (int)$m[2], 'day' => (int)$m[3]];
+        }
+        return ['@type' => 'PartialDate', 'year' => 0, 'month' => 1, 'day' => 1];
+    }
+}


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3
<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Stalwart JMAP support for Z-Push.  


Where has this been tested?
---------------------------
Email:

-   Receiving
-   Sending (From name is taken from Stalwart settings / Jmap)
-  Addressbooks 
-  Calendar
- Supports PHP 8.4 and has been tested with Stalwart v0.15.

I have used it for about a week with Samsung Email without anyissues.
Claude Code has helped me with the implementation.

 - OS: Linux
 - PHP Version:  8.4
 - Backend for:  Stalwart 
 - and Version: v0.15.
