### PR TITLE
[BackendIMAP] Fix GetMailboxSearchResults ignoring Range start

### DIFF
--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -2145,6 +2145,25 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
 
             $p = 0;
             $pc = 0;
+            // $rangestart is the offset into the flat (cross-folder)
+            // result stream. Without this skip-ahead, $pc starts at 0
+            // and the emit loop reads $listMessages[0..N-1] regardless
+            // of $rangestart — every page of search results would look
+            // like page one. Walk $p/$pc forward until they point at
+            // the requested item.
+            $toSkip = $rangestart;
+            while ($toSkip > 0 && $p < count($listMessages)) {
+                $keys = array_keys($listMessages[$p]);
+                $cntFolder = count($listMessages[$p][$keys[0]]);
+                if ($cntFolder <= $toSkip) {
+                    $toSkip -= $cntFolder;
+                    $p++;
+                }
+                else {
+                    $pc = $toSkip;
+                    $toSkip = 0;
+                }
+            }
             for ($i = $rangestart, $j = 0; $i <= $rangeend && $i < $querycnt; $i++, $j++) {
                 $keys = array_keys($listMessages[$p]);
                 $cntFolder = count($listMessages[$p][$keys[0]]);


### PR DESCRIPTION
Fixes #188.

The Search emit loop in `BackendIMAP::GetMailboxSearchResults` initialized `$pc` (the index into the per-folder result list) to 0 and never offset it by `$rangestart`, so every paginated Search returned items 0..N-1 regardless of the requested window. The result was that every page of search results looked like page one — pagination past the first page of search hits was effectively impossible.

The loop already used `$rangestart` correctly as the upper-bound guard on `$i`, but `$pc` was only ever incremented by 1 per iteration starting from 0. With `$rangestart > 0`, the loop just ran fewer iterations and still read from the start of the array.

This patch walks `$p` / `$pc` forward across the (possibly multi-folder) `$listMessages` stream until they point at item `$rangestart`, then runs the existing emit loop. For deep-traversal searches, multiple per-folder result lists in `$listMessages` are treated as one concatenated stream, advancing `$p` when the current folder is exhausted.

### Reproduction (against z-push 2.7.6 + Dovecot, BackendCombined + BackendIMAP, EAS 14.0)

Send 5 messages all matching token `"validate-…"`, then run two paginated Search requests:

```
Before:
  Search Range "0-1" -> msg 0, msg 1
  Search Range "3-4" -> msg 0, msg 1   (same items returned)

After:
  Search Range "0-1" -> msg 0, msg 1
  Search Range "3-4" -> msg 3, msg 4   (correct window)
```

Validated end-to-end against a live Z-Push 2.7.6 deployment by patching the file in place and re-running the probe — included full transcript in the linked issue. The same buggy code is present on `develop` (the diff there is identical to this PR modulo line numbers, since `develop`'s nearby additions like `serverid` don't intersect the loop's preamble).

### License

Released under the GNU Affero General Public License (AGPL), version 3.