### PR TITLE
[BackendIMAP] Honor BodyPreference TruncationSize in GetMessage

### DIFF
--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -1256,8 +1256,45 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
                     }
                 }
                 else {
-                    if (strlen($data) > $truncsize) {
-                        $data = Utils::Utf8_truncate($data, $truncsize);
+                    // Prefer the AirSyncBase BodyPreference's per-type
+                    // TruncationSize (the AS-12+ field) over the legacy
+                    // <Truncation> element's $truncsize. AS-12+ clients
+                    // (Outlook, every modern EAS client) send their
+                    // body-size budget via <BodyPreference><TruncationSize>
+                    // and don't set the legacy field, so without this the
+                    // legacy default (1024 from Utils::GetTruncSize) — or
+                    // SYNC_TRUNCATION_ALL when called via Fetch (Search /
+                    // ItemOperations) — silently fires regardless of what
+                    // the client requested.
+                    //
+                    // If the chosen return type doesn't have a per-type
+                    // BodyPreference (we may have promoted Plain→HTML
+                    // above when no plain part exists), fall back to the
+                    // smallest TruncationSize across whatever preferences
+                    // the client did send: that's the tightest body-size
+                    // budget the caller expressed.
+                    $effectiveTrunc = $truncsize;
+                    $bpoTrunc = $contentparameters->BodyPreference($bpReturnType);
+                    if ($bpoTrunc !== false && $bpoTrunc->GetTruncationSize() > 0) {
+                        $effectiveTrunc = $bpoTrunc->GetTruncationSize();
+                    }
+                    elseif (is_array($bodypreference) && !empty($bodypreference)) {
+                        $bestBpTrunc = false;
+                        foreach ($bodypreference as $bpType) {
+                            $bpo = $contentparameters->BodyPreference($bpType);
+                            if ($bpo !== false && $bpo->GetTruncationSize() > 0) {
+                                $sz = $bpo->GetTruncationSize();
+                                if ($bestBpTrunc === false || $sz < $bestBpTrunc) {
+                                    $bestBpTrunc = $sz;
+                                }
+                            }
+                        }
+                        if ($bestBpTrunc !== false) {
+                            $effectiveTrunc = $bestBpTrunc;
+                        }
+                    }
+                    if (strlen($data) > $effectiveTrunc) {
+                        $data = Utils::Utf8_truncate($data, $effectiveTrunc);
                         $output->asbody->truncated = 1;
                     }
                     else {


### PR DESCRIPTION
The body-truncation step in `BackendIMAP::GetMessage` exclusively used the legacy `<Truncation>` field via \`\$truncsize = Utils::GetTruncSize(...)\`. AS-12+ clients (Outlook, every modern EAS client) never send the legacy field; they express their body-size budget through `<BodyPreference><TruncationSize>` instead. With \`\$truncsize\` ignoring that, the legacy default (1024 bytes from `Utils::GetTruncSize`) silently fires regardless of what the client requested.

It gets worse on the Search and ItemOperations paths. `BackendDiff::Fetch` (the path both of those take) hard-codes \`SetTruncation(SYNC_TRUNCATION_ALL)\` — i.e. 1 MiB — before invoking GetMessage. So Search hits get the *full* body up to 1 MiB regardless of the client's BodyPreference. On HTML-heavy folders (marketing mail, calendar invites, etc.) a single hit can be 30–500 KiB and overflow downstream consumers' result-size limits very quickly. Documented downstream at: https://github.com/hstern/activesync-mcp/issues/13.

### Fix

In the non-MIME truncation branch, prefer the `BodyPreference`'s per-type `TruncationSize` over `\$truncsize`. Two-step lookup:

1. `BodyPreference(\$bpReturnType)->GetTruncationSize()` — the preference for the type we're about to return.
2. If that's unset (we may have promoted Plain→HTML above when no plain part exists, so the client's Plain preference no longer matches the chosen return type), fall back to the **smallest** `TruncationSize` across whatever preferences the client did send. That's the tightest budget the caller expressed and matches what most modern AS clients intend.
3. Otherwise fall through to the legacy `\$truncsize`.

### Reproduction (against z-push 2.7.6 + Dovecot + BackendCombined+BackendIMAP, ASV 14.0, single Search hit with a 5543-byte HTML body)

**Before:**

```
ask=256   → body_len=5543  truncated=false
ask=1024  → body_len=5543  truncated=false
ask=10000 → body_len=5543  truncated=false
```

**After:**

```
ask=256   → body_len=256   truncated=true
ask=1024  → body_len=1024  truncated=true
ask=10000 → body_len=5543  truncated=false   (body fits within budget)
```

Validated live against the testenv I used for #189 (same machine, same PHP, just with this patch applied to the running container).

### License

Released under the GNU Affero General Public License (AGPL), version 3.