### PR TITLE
BackendIMAP: fall back to INTERNALDATE when message has no Date header

### DIFF
--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -1318,7 +1318,17 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
             unset($textBody);
             unset($mail_headers);
 
-            $output->datereceived = isset($message->headers["date"]) ? $this->cleanupDate($message->headers["date"]) : null;
+            if (isset($message->headers["date"])) {
+                $output->datereceived = $this->cleanupDate($message->headers["date"]);
+            }
+            else {
+                // Fall back to IMAP INTERNALDATE for messages without a Date: header
+                // (e.g. RFC 5322 violators such as some IP cameras). Otherwise
+                // $output->datereceived would be null and EAS clients (iOS Mail etc.)
+                // display the sync time instead of the actual receipt time.
+                $overview = @imap_fetch_overview($this->mbox, $id, FT_UID);
+                $output->datereceived = (is_array($overview) && !empty($overview) && isset($overview[0]->udate)) ? $overview[0]->udate : null;
+            }
 
             if ($is_smime) {
                 // #190, KD 2015-06-04 - Add Encrypted (and possibly signed) to the classifications emitted


### PR DESCRIPTION
## Summary

Some MUAs - notably many IP camera firmwares and other RFC 5322 violators -
send mail without a `Date:` header. BackendIMAP currently sets
`$output->datereceived = null` in that case (see [imap.php:1321](https://github.com/Z-Hub/Z-Push/blob/develop/src/backend/imap/imap.php#L1321)),
and EAS clients (iOS Mail, etc.) then display the **sync time** rather
than the actual receipt time. So a camera alarm that arrived at 02:00
shows up as *received at 09:15* the next morning, whenever the phone
reconnects.

This PR falls back to the IMAP `INTERNALDATE` (`udate` from
`imap_fetch_overview`) when no `Date:` header is present. The IMAP
server already stores this timestamp at delivery time, so it matches
when the message actually hit the mailbox.

## Change

One spot in `src/backend/imap/imap.php`, branch the existing ternary
into an `if/else`:

```diff
- $output->datereceived = isset($message->headers["date"]) ? $this->cleanupDate($message->headers["date"]) : null;
+ if (isset($message->headers["date"])) {
+     $output->datereceived = $this->cleanupDate($message->headers["date"]);
+ }
+ else {
+     // Fall back to IMAP INTERNALDATE for messages without a Date: header
+     $overview = @imap_fetch_overview($this->mbox, $id, FT_UID);
+     $output->datereceived = (is_array($overview) && !empty($overview) && isset($overview[0]->udate)) ? $overview[0]->udate : null;
+ }
```

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Message with valid `Date:` header | uses Date header (unchanged) | uses Date header (unchanged) |
| Message with no `Date:` header | `datereceived = null` -> EAS client shows sync time | `datereceived = INTERNALDATE` -> EAS client shows real delivery time |
| `imap_fetch_overview` fails | n/a | `datereceived = null` (same as today) |

No regression for well-formed mail. Only changes behaviour for the
already-broken null case.

## Tested

In production with Dovecot 2.3 + Z-Push 2.7.6 + multiple IP cameras
sending header-less SMTP. iOS Mail (iOS 26) now shows the actual
delivery timestamp on the camera alarm emails.

## License

Released under the GNU Affero General Public License (AGPL), version 3.