### PR TITLE
Coerce WBXMLEncoder::content() output to valid UTF-8

### DIFF
--- a/src/lib/wbxml/wbxmlencoder.php
+++ b/src/lib/wbxml/wbxmlencoder.php
@@ -151,6 +151,16 @@ class WBXMLEncoder extends WBXMLDefs {
         // cannot send \0 characters within the XML content anywhere.
         $content = str_replace("\0","",$content);
 
+        // The WBXML document is declared as UTF-8 in the header (see startWBXML()). Any invalid byte
+        // sequence in the content makes the whole response unparseable for strict clients: iOS rejects
+        // it and re-requests the same item forever, which Z-Push then reports as "Mobile loop detected"
+        // and eventually ignores as a broken message. This happens with otherwise-fine mails whose
+        // headers carry raw 8-bit bytes (e.g. a Thread-Topic with a Latin-1 "\xE7" instead of UTF-8).
+        // Coerce to valid UTF-8 so a single bad header can no longer wedge a folder's sync.
+        if ($content !== "" && !mb_check_encoding($content, "UTF-8")) {
+            $content = mb_convert_encoding($content, "UTF-8", "UTF-8");
+        }
+
         if("x" . $content == "x")
             return;
         $this->_outputStack();


### PR DESCRIPTION
`WBXMLEncoder->content()` filters out NUL bytes but does not guarantee the content is valid UTF-8, even though the WBXML document is declared as UTF-8 in `startWBXML()`. When a string field contains an invalid byte sequence, the whole response becomes unparseable for strict clients.

I hit this with a real message: a Thread-Topic header containing a bare Latin-1 `0xE7` ("ç") while the Subject was correctly RFC2047-encoded. `BackendIMAP->GetMessage()` copies the decoded `thread-topic` straight into `SyncMail->threadtopic` with no encoding sanitisation (the existing `CheckAndFixEncodingInHeaders()` only touches subject/from, and only repairs ISO-2022-JP), so the raw byte reaches the `ThreadTopic` WBXML string.

The symptom is distinctive: every device stalls on the **same** message, the log repeats `Mobile loop detected` followed by `Ignored broken message (SyncMail) Reason: '2'` for that item on every sync, and the ignore never sticks (the item re-enters the next sync window). IMAP/webmail are completely unaffected because they never build WBXML. iOS in particular rejects the malformed response and re-requests the same SyncKey indefinitely.

This fixes it at the encoder chokepoint, right next to the existing NUL filter, so the UTF-8 invariant is enforced once for every field from every backend rather than patching the single header that happened to trigger it here. `mb_check_encoding()` avoids touching the common (already-valid) case, and `mb_convert_encoding($content, "UTF-8", "UTF-8")` substitutes invalid sequences for valid messages (one byte in, one byte out for the `0xE7` case).

Verified against a live Z-Push 2.7.6 install (iRedMail): drove the real `WBXMLEncoder->content()` with the offending header — invalid-UTF-8 output before, valid-UTF-8 output after — and confirmed both stuck iOS devices recovered and the folder finished syncing once the patched code was loaded.

I release this contribution under the GNU Affero General Public License, version 3 (AGPLv3).
