### PR TITLE
Extensionless CardDAV contacts are omitted from sync results

### DIFF
--- a/src/include/z_carddav.php
+++ b/src/include/z_carddav.php
@@ -416,6 +416,7 @@ EOFCONTENTSEARCH;
     <D:sync-level>1</D:sync-level>
     <D:prop>
         <D:getetag/>
+        <D:getcontenttype/>
         <D:getlastmodified/>
     </D:prop>
 </D:sync-collection>


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3

What does this implement/fix? Explain your changes.
---------------------------------------------------

CardDAV sync-token reports currently request each changed resource's ETag and
last-modified time, but not its content type. The response parser already uses
`getcontenttype` to recognize vCards. Without that property, it falls back to
recognizing contacts by a `.vcf` suffix, so valid extensionless CardDAV
resources can be omitted from sync results.

This adds `DAV:getcontenttype` to the existing `sync-collection` property
request. It uses the metadata path the parser already supports and does not
change behavior for servers that use `.vcf` resource names.

We hit this with Z-Push translating ActiveSync contacts for the Gmail Android
app to a Stalwart CardDAV address book. Stalwart uses valid extensionless
resource URLs, which exposed the suffix assumption. The fix is generic to
CardDAV servers that return extensionless contact resources.

Does this close any currently open issues?
------------------------------------------

No known open issue.

Any relevant logs, error output, etc?
-------------------------------------

The sync REPORT returned changed extensionless resources, but the simplified
response omitted them because neither a `.vcf` suffix nor
`DAV:getcontenttype` was available to the existing vCard check.

Where has this been tested?
---------------------------

- PHP syntax check: PHP 8.4.23
- Backend path: Z-Push CardDAV sync-collection against Stalwart CardDAV
- Client path: Gmail for Android through Exchange ActiveSync

