### PR TITLE
ActiveSync calendar writes ignore explicit Windows timezone names

### DIFF
--- a/src/backend/caldav/caldav.php
+++ b/src/backend/caldav/caldav.php
@@ -2005,6 +2005,24 @@ class BackendCalDAV extends BackendDiff {
         ,"600/-60/0/0/0/0/0/0/0/0"=>"Pacific/Honolulu"
     );
 
+    private static function normalizeMSTZName($name) {
+        return trim(str_replace("\0", "", (string)$name));
+    }
+
+    /**
+     * Prefer explicit Windows time zone names over offset-only matching.
+     * Multiple regions share the same ActiveSync bias and DST signature.
+     */
+    private static function tzidFromWindowsName($name) {
+        $name = self::normalizeMSTZName($name);
+        if ($name !== "" && ($tzid = TimezoneUtil::GetPhpTimezoneFromWinTZName($name))) {
+            ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendCalDAV->tzidFromMSTZ(): Found tzid from Windows timezone name '%s': '%s'.", $name, $tzid));
+            return $tzid;
+        }
+
+        return null;
+    }
+
     /**
      * Given the MS timezone find a matching tzid, for the year the event starts in.
      * @param string $mstz
@@ -2017,6 +2035,15 @@ class BackendCalDAV extends BackendDiff {
                                     ."vdstendminute/vdstendsecond/vdstendmillis/lstdbias/Z64tznamedst/vdststartyear/"
                                     ."vdststartmonth/vdststartday/vdststartweek/vdststarthour/vdststartminute/"
                                     ."vdststartsecond/vdststartmillis/ldstbias", base64_decode($mstz));
+
+        if (($tzid = self::tzidFromWindowsName($mstz_parts['tzname']))) {
+            return $tzid;
+        }
+
+        if (($tzid = self::tzidFromWindowsName($mstz_parts['tznamedst']))) {
+            return $tzid;
+        }
+
         $mstz = $mstz_parts['bias']
                     ."/".$mstz_parts['dstbias']
                     ."/".$mstz_parts['dstendmonth']

--- a/src/lib/utils/timezoneutil.php
+++ b/src/lib/utils/timezoneutil.php
@@ -1380,6 +1380,52 @@ class TimezoneUtil {
     }
 
     /**
+     * Returns a PHP-supported IANA timezone for a Windows timezone name.
+     *
+     * @param string $winTz Timezone name in Windows, e.g. "W. Europe Standard Time"
+     *
+     * @access public
+     * @return string|false
+     */
+    public static function GetPhpTimezoneFromWinTZName($winTz = false) {
+        if ($winTz === false) {
+            return false;
+        }
+
+        $winTz = trim(str_replace("\0", "", (string)$winTz));
+        if ($winTz === "") {
+            return false;
+        }
+
+        $candidateNames = array($winTz);
+        foreach (self::$mstzones as $msdefs) {
+            if ($msdefs[0] == $winTz) {
+                foreach (self::$mstzones as $candidateDefs) {
+                    if ($candidateDefs[1] == $msdefs[1] && !in_array($candidateDefs[0], $candidateNames, true)) {
+                        $candidateNames[] = $candidateDefs[0];
+                    }
+                }
+                break;
+            }
+        }
+
+        $phpTimezoneIds = DateTimeZone::listIdentifiers();
+        foreach ($candidateNames as $candidateName) {
+            if (!isset(self::$phptimezones[$candidateName])) {
+                continue;
+            }
+
+            foreach (self::$phptimezones[$candidateName] as $phpTz) {
+                if (in_array($phpTz, $phpTimezoneIds, true)) {
+                    return $phpTz;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Returns official timezone name from windows timezone name.
      * E.g. "W Europe Standard Time" for "(GMT+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna".
      *


### PR DESCRIPTION
Released under the GNU Affero General Public License (AGPL), version 3

What does this implement/fix? Explain your changes.
---------------------------------------------------

When Z-Push converts an ActiveSync calendar write to CalDAV, the timezone blob
contains both an explicit Windows timezone name and numeric bias/DST fields.
`BackendCalDAV::tzidFromMSTZ()` currently ignores the names and guesses from
the numeric fields first. Those fields are not globally unique, so a normal
regional timezone can be mapped to an unrelated IANA zone with the same
signature.

This change:

- reads the standard and daylight Windows names already present in the blob;
- resolves them through Z-Push's existing Windows-to-IANA tables before
  falling back to the current numeric matching;
- supports aliases such as `W. Europe Standard Time` by following equivalent
  entries in `$mstzones`; and
- returns only timezone identifiers supported by the running PHP installation.

We observed this with Gmail for Android writing an ActiveSync event through
Z-Push into Stalwart CalDAV. The explicit timezone described the user's region,
while offset-only matching selected `Antarctica/Casey`. The resulting event
then displayed at the wrong local time. This is a protocol-boundary fix and is
not specific to Stalwart or Gmail.

Does this close any currently open issues?
------------------------------------------

Related to #39, which reports that Microsoft timezone names such as
`W. Europe Standard Time` are not mapped through the existing timezone data.

Any relevant logs, error output, etc?
-------------------------------------

The old fallback logged a timezone selected solely from bias and transition
fields even though the decoded ActiveSync blob carried an explicit Windows
timezone name.

Where has this been tested?
---------------------------

- PHP syntax check: PHP 8.4.23
- Resolver checks:
  - `W. Europe Standard Time` -> `Europe/Amsterdam`
  - `Singapore Standard Time` -> `Asia/Singapore`
- Backend path: Z-Push CalDAV writes to Stalwart
- Client path: Gmail for Android through Exchange ActiveSync

